### PR TITLE
feat: add random split checker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/crypto2"
 
 [dev-dependencies]
 hex = "0.4"
+rand = "0.8"
 
 [features]
 default = [

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -7,6 +7,9 @@ mod sha2;
 // TODO: 暂未实现
 mod sha3;
 
+#[cfg(test)]
+mod random_split_test;
+
 pub use self::md2::*;
 pub use self::md4::*;
 pub use self::md5::*;

--- a/src/hash/random_split_test.rs
+++ b/src/hash/random_split_test.rs
@@ -1,36 +1,35 @@
 pub mod test {
+    use super::super::{Md2, Md4, Md5, Sha1, Sha224, Sha256, Sha384, Sha512, Sm3};
     use rand::{thread_rng, Rng, RngCore};
-    use super::super::{md2::Md2, md4::Md4, md5::Md5, sha1::Sha1, sm3::Sm3};
-    use crate::hash::{Sha256, Sha512};
 
     macro_rules! random_split_test {
-    ($x:ident) => {
-        for stream_size in 2..1024 {
-            let mut buffer = vec![0u8; stream_size];
-            thread_rng().fill_bytes(&mut buffer);
+        ($x:ident) => {
+            for stream_size in 2..1024 {
+                let mut buffer = vec![0u8; stream_size];
+                thread_rng().fill_bytes(&mut buffer);
 
-            let h1 = $x::oneshot(&buffer);
+                let h1 = $x::oneshot(&buffer);
 
-            let break_size = thread_rng().gen_range(1..stream_size);
-            let left = &buffer[..break_size];
-            let right = &buffer[break_size..];
+                let break_size = thread_rng().gen_range(1..stream_size);
+                let left = &buffer[..break_size];
+                let right = &buffer[break_size..];
 
-            let mut ctx = $x::new();
-            ctx.update(left);
-            ctx.update(right);
-            let h2 = ctx.finalize();
+                let mut ctx = $x::new();
+                ctx.update(left);
+                ctx.update(right);
+                let h2 = ctx.finalize();
 
-            debug_assert_eq!(
-                h1,
-                h2,
-                "expect same result when a stream with size {:} is broken into {:} and {:}",
-                stream_size,
-                break_size,
-                stream_size - break_size
-            );
-        }
-    };
-}
+                debug_assert_eq!(
+                    h1,
+                    h2,
+                    "expect same result when a stream with size {:} is broken into {:} and {:}",
+                    stream_size,
+                    break_size,
+                    stream_size - break_size
+                );
+            }
+        };
+    }
 
     #[test]
     fn random_split_test_md2() {
@@ -58,8 +57,18 @@ pub mod test {
     }
 
     #[test]
+    fn random_split_test_sha224() {
+        random_split_test!(Sha224);
+    }
+
+    #[test]
     fn random_split_test_sha256() {
         random_split_test!(Sha256);
+    }
+
+    #[test]
+    fn random_split_test_sha384() {
+        random_split_test!(Sha384);
     }
 
     #[test]

--- a/src/hash/random_split_test.rs
+++ b/src/hash/random_split_test.rs
@@ -1,0 +1,69 @@
+pub mod test {
+    use rand::{thread_rng, Rng, RngCore};
+    use super::super::{md2::Md2, md4::Md4, md5::Md5, sha1::Sha1, sm3::Sm3};
+    use crate::hash::{Sha256, Sha512};
+
+    macro_rules! random_split_test {
+    ($x:ident) => {
+        for stream_size in 2..1024 {
+            let mut buffer = vec![0u8; stream_size];
+            thread_rng().fill_bytes(&mut buffer);
+
+            let h1 = $x::oneshot(&buffer);
+
+            let break_size = thread_rng().gen_range(1..stream_size);
+            let left = &buffer[..break_size];
+            let right = &buffer[break_size..];
+
+            let mut ctx = $x::new();
+            ctx.update(left);
+            ctx.update(right);
+            let h2 = ctx.finalize();
+
+            debug_assert_eq!(
+                h1,
+                h2,
+                "expect same result when a stream with size {:} is broken into {:} and {:}",
+                stream_size,
+                break_size,
+                stream_size - break_size
+            );
+        }
+    };
+}
+
+    #[test]
+    fn random_split_test_md2() {
+        random_split_test!(Md2);
+    }
+
+    #[test]
+    fn random_split_test_md4() {
+        random_split_test!(Md4);
+    }
+
+    #[test]
+    fn random_split_test_md5() {
+        random_split_test!(Md5);
+    }
+
+    #[test]
+    fn random_split_test_sha1() {
+        random_split_test!(Sha1);
+    }
+
+    #[test]
+    fn random_split_test_sm3() {
+        random_split_test!(Sm3);
+    }
+
+    #[test]
+    fn random_split_test_sha256() {
+        random_split_test!(Sha256);
+    }
+
+    #[test]
+    fn random_split_test_sha512() {
+        random_split_test!(Sha512);
+    }
+}


### PR DESCRIPTION
this pull request enhances #10.
now it fails md4, md5, sha1, sha256 and sha512.