### PR TITLE
multiple refinement for workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,17 +20,34 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Rust
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
         components: clippy
         override: true
+    - name: Setup Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Check
+      uses: actions-rs/clippy-check@v1
+      with:
+        name: clippy-${{ matrix.platform }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: |
+          --all-features --verbose -- -Z macro-backtrace
+          -W clippy::absurd_extreme_comparisons
+          -W clippy::erasing_op
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
+    - name: Test
       run: cargo test --verbose
-    - name: Build
-      run: cargo build --verbose
-    - name: Build docs
+    - name: Docs
       run: cargo doc --verbose

--- a/src/blockmode/gcm_siv.rs
+++ b/src/blockmode/gcm_siv.rs
@@ -17,7 +17,7 @@ use crate::blockcipher::{
 
 const GCM_SIV_BLOCK_LEN: usize = 16;
 
-            
+/// FIXME: rewrite derive_keys() implementation to dismiss the warning.
 macro_rules! impl_block_cipher_with_gcm_siv_mode {
     ($name:tt, $cipher:tt) => {
 
@@ -77,6 +77,7 @@ macro_rules! impl_block_cipher_with_gcm_siv_mode {
             }
             
             #[inline]
+            #[allow(clippy::out_of_bounds_indexing)]
             fn derive_keys(&self, nonce: &[u8]) -> ($cipher, Polyval) {
                 let mut counter_block = [0u8; Self::BLOCK_LEN];
                 counter_block[4..16].copy_from_slice(nonce);


### PR DESCRIPTION
refine clippy (DuckSoft/crypto2#3)

* use github clippy
* Update rust.yml
* Update rust.yml
* Update rust.yml
* ignore clippy::out_of_bounds_indexing for derive_keys
which will disable clippy alert on this.
we may want to fix this later.

(cherry picked from commit 74bbb305d43ea43f580172535b01c1d3215ed0e4)

add cache for cargo (DuckSoft/crypto2#4)

* add cache for cargo
* test cache speed
* restore test status

(cherry picked from commit f7ee6c8b3dad92c0f05e8ea10e84025262ad3b9b)

Update rust.yml

(cherry picked from commit df9d43ca2de741d1b8eccf630dd00805a9b99610)

workflow: add clippy check

(cherry picked from commit 73403ddd8159878a8c1a48a5c59c3a472fda776e)