### PR TITLE
enable optimization dynamically if target-feature is unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/crypto2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
+cfg-if = "1"
 
 [dev-dependencies]
 hex = "0.4"
@@ -23,7 +23,6 @@ default = [
 ]
 
 std     = [ ]
-nightly = [ ]
 openssh = [ ]
 
 

--- a/src/blockcipher/aes/dynamic.rs
+++ b/src/blockcipher/aes/dynamic.rs
@@ -1,0 +1,63 @@
+use std::fmt::{self, Debug};
+
+use super::generic;
+use super::platform;
+
+macro_rules! impl_dynamic_dispatch {
+    ($name:ident) => {
+        #[derive(Clone)]
+        pub enum $name {
+            Generic(generic::$name),
+            Platform(platform::$name),
+        }
+
+        impl Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match *self {
+                    $name::Generic(ref d) => Debug::fmt(d, f),
+                    $name::Platform(ref d) => Debug::fmt(d, f),
+                }
+            }
+        }
+
+        impl $name {
+            pub const KEY_LEN: usize = generic::$name::KEY_LEN;
+            pub const BLOCK_LEN: usize = generic::$name::BLOCK_LEN;
+
+            #[inline]
+            pub fn new(key: &[u8]) -> $name {
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                if std::is_x86_feature_detected!("aes") && std::is_x86_feature_detected!("sse2") {
+                    return $name::Platform(platform::$name::new(key));
+                }
+
+                #[cfg(target_arch = "aarch64")]
+                if std::is_aarch64_feature_detected!("aes") {
+                    return $name::Platform(platform::$name::new(key));
+                }
+
+                $name::Generic(generic::$name::new(key))
+            }
+
+            #[inline]
+            pub fn encrypt(&self, plaintext_in_ciphertext_out: &mut [u8]) {
+                match *self {
+                    $name::Generic(ref c) => c.encrypt(plaintext_in_ciphertext_out),
+                    $name::Platform(ref c) => c.encrypt(plaintext_in_ciphertext_out),
+                }
+            }
+
+            #[inline]
+            pub fn decrypt(&self, ciphertext_in_plaintext_out: &mut [u8]) {
+                match *self {
+                    $name::Generic(ref c) => c.decrypt(ciphertext_in_plaintext_out),
+                    $name::Platform(ref c) => c.decrypt(ciphertext_in_plaintext_out),
+                }
+            }
+        }
+    };
+}
+
+impl_dynamic_dispatch!(Aes128);
+impl_dynamic_dispatch!(Aes192);
+impl_dynamic_dispatch!(Aes256);

--- a/src/blockcipher/aes/mod.rs
+++ b/src/blockcipher/aes/mod.rs
@@ -1,48 +1,50 @@
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    all(target_feature = "aes", target_feature = "sse2")
-))]
-#[path = "./x86.rs"]
-mod platform;
+use cfg_if::cfg_if;
 
+cfg_if! {
+    if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
+                 all(target_feature = "aes", target_feature = "sse2")))] {
+        mod x86;
+        pub use self::x86::*;
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "crypto"))] {
+        // NOTE:
+        //      Crypto: AES + PMULL + SHA1 + SHA2
+        //      https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L26
+        mod aarch64;
+        pub use self::aarch64::*;
+    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {
+        // Check for platform specific optimizations dynamically
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[path = "./x86.rs"]
+        mod platform;
 
-// NOTE:
-//      Crypto: AES + PMULL + SHA1 + SHA2
-//      https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L26
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto"))]
-#[path = "./aarch64.rs"]
-mod platform;
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto"))]
-#[allow(dead_code)]
-mod generic;
+        #[cfg(target_arch = "aarch64")]
+        #[path = "./aarch64.rs"]
+        mod platform;
 
+        mod generic;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        all(target_feature = "aes", target_feature = "sse2")
-    ),
-    all(target_arch = "aarch64", target_feature = "crypto")
-)))]
-#[path = "./generic.rs"]
-mod platform;
-
-pub use self::platform::*;
-
-
+        mod dynamic;
+        pub use self::dynamic::*;
+    } else {
+        mod generic;
+        pub use self::generic::*;
+    }
+}
 
 #[test]
 fn test_aes128() {
     // AES 128
     let key = hex::decode("000102030405060708090a0b0c0d0e0f").unwrap();
     let plaintext = hex::decode("00112233445566778899aabbccddeeff").unwrap();
-    
+
     let cipher = Aes128::new(&key);
 
     let mut ciphertext = plaintext.clone();
     cipher.encrypt(&mut ciphertext);
-    assert_eq!(&ciphertext[..],
-        &hex::decode("69c4e0d86a7b0430d8cdb78070b4c55a").unwrap()[..]);
+    assert_eq!(
+        &ciphertext[..],
+        &hex::decode("69c4e0d86a7b0430d8cdb78070b4c55a").unwrap()[..]
+    );
 
     let mut cleartext = ciphertext.clone();
     cipher.decrypt(&mut cleartext);
@@ -53,13 +55,15 @@ fn test_aes128() {
 fn test_aes192() {
     let key = hex::decode("000102030405060708090a0b0c0d0e0f1011121314151617").unwrap();
     let plaintext = hex::decode("00112233445566778899aabbccddeeff").unwrap();
-    
+
     let cipher = Aes192::new(&key);
-    
+
     let mut ciphertext = plaintext.clone();
     cipher.encrypt(&mut ciphertext);
-    assert_eq!(&ciphertext[..],
-        &hex::decode("dda97ca4864cdfe06eaf70a0ec0d7191").unwrap()[..]);
+    assert_eq!(
+        &ciphertext[..],
+        &hex::decode("dda97ca4864cdfe06eaf70a0ec0d7191").unwrap()[..]
+    );
 
     let mut cleartext = ciphertext.clone();
     cipher.decrypt(&mut cleartext);
@@ -69,15 +73,18 @@ fn test_aes192() {
 #[test]
 fn test_aes256() {
     // AES 256
-    let key = hex::decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f").unwrap();
+    let key =
+        hex::decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f").unwrap();
     let plaintext = hex::decode("00112233445566778899aabbccddeeff").unwrap();
-    
+
     let cipher = Aes256::new(&key);
 
     let mut ciphertext = plaintext.clone();
     cipher.encrypt(&mut ciphertext);
-    assert_eq!(&ciphertext[..],
-        &hex::decode("8ea2b7ca516745bfeafc49904b496089").unwrap()[..]);
+    assert_eq!(
+        &ciphertext[..],
+        &hex::decode("8ea2b7ca516745bfeafc49904b496089").unwrap()[..]
+    );
 
     let mut cleartext = ciphertext.clone();
     cipher.decrypt(&mut cleartext);

--- a/src/hash/sha2/sha512/mod.rs
+++ b/src/hash/sha2/sha512/mod.rs
@@ -54,7 +54,7 @@ const SHA384_INITIAL_STATE: [u64; 8] = [
 #[cfg(target_arch = "aarch64")]
 #[inline]
 fn transform(state: &mut [u64; 8], block: &[u8]) {
-    // NOTE: 等待 Rust 的 `std_detect` 库支持 AArch64 v8.4-A。
+    // Waiting `std_detect` to support AArch64 v8.4-A
     // https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L13
     
     generic::transform(state, block)

--- a/src/mac/ghash/dynamic.rs
+++ b/src/mac/ghash/dynamic.rs
@@ -1,0 +1,42 @@
+use super::generic;
+use super::platform;
+
+#[derive(Clone)]
+pub enum GHash {
+    Generic(generic::GHash),
+    Platform(platform::GHash),
+}
+
+impl GHash {
+    pub const KEY_LEN: usize = generic::GHash::KEY_LEN;
+    pub const BLOCK_LEN: usize = generic::GHash::BLOCK_LEN;
+    pub const TAG_LEN: usize = generic::GHash::TAG_LEN;
+
+    pub fn new(h: &[u8; Self::BLOCK_LEN]) -> Self {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if std::is_x86_feature_detected!("sse2") && std::is_x86_feature_detected!("pclmulqdq") {
+            return GHash::Platform(platform::GHash::new(h));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        if std::is_aarch64_feature_detected!("pmull") {
+            return GHash::Platform(platform::GHash::new(k));
+        }
+
+        GHash::Generic(generic::GHash::new(h))
+    }
+
+    pub fn update(&mut self, m: &[u8]) {
+        match *self {
+            GHash::Generic(ref mut g) => g.update(m),
+            GHash::Platform(ref mut g) => g.update(m),
+        }
+    }
+
+    pub fn finalize(self) -> [u8; Self::TAG_LEN] {
+        match self {
+            GHash::Generic(g) => g.finalize(),
+            GHash::Platform(g) => g.finalize(),
+        }
+    }
+}

--- a/src/mac/ghash/mod.rs
+++ b/src/mac/ghash/mod.rs
@@ -1,29 +1,30 @@
 // https://github.com/randombit/botan/blob/master/src/lib/utils/ghash/ghash_vperm/ghash_vperm.cpp
 
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    all(target_feature = "sse2", target_feature = "pclmulqdq"),
-))]
-#[path = "./x86.rs"]
-mod platform;
+use cfg_if::cfg_if;
 
+cfg_if! {
+    if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
+                 all(target_feature = "sse2", target_feature = "pclmulqdq")))] {
+        mod x86;
+        pub use self::x86::GHash;
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "crypto"))] {
+        mod aarch64;
+        pub use self::aarch64::GHash;
+    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[path = "./x86.rs"]
+        mod platform;
 
-// NOTE:
-//      Crypto: AES + PMULL + SHA1 + SHA2
-//      https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L26
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto"))]
-#[path = "./aarch64.rs"]
-mod platform;
+        #[cfg(target_arch = "aarch64")]
+        #[path = "./aarch64.rs"]
+        mod platform;
 
+        mod generic;
+        mod dynamic;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        all(target_feature = "sse2", target_feature = "pclmulqdq")
-    ),
-    all(target_arch = "aarch64", target_feature = "crypto")
-)))]
-#[path = "./generic.rs"]
-mod platform;
-
-pub use self::platform::GHash;
+        pub use self::dynamic::GHash;
+    } else {
+        mod generic;
+        pub use self::generic::GHash;
+    }
+}

--- a/src/mac/polyval/dynamic.rs
+++ b/src/mac/polyval/dynamic.rs
@@ -1,0 +1,41 @@
+use super::generic;
+use super::platform;
+
+pub enum Polyval {
+    Generic(generic::Polyval),
+    Platform(platform::Polyval),
+}
+
+impl Polyval {
+    pub const KEY_LEN: usize = generic::Polyval::KEY_LEN;
+    pub const BLOCK_LEN: usize = generic::Polyval::BLOCK_LEN;
+    pub const TAG_LEN: usize = generic::Polyval::TAG_LEN;
+
+    pub fn new(k: &[u8]) -> Self {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if std::is_x86_feature_detected!("sse2") && std::is_x86_feature_detected!("pclmulqdq") {
+            return Polyval::Platform(platform::Polyval::new(k));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        if std::is_aarch64_feature_detected!("pmull") {
+            return Polyval::Platform(platform::Polyval::new(k));
+        }
+
+        Polyval::Generic(generic::Polyval::new(k))
+    }
+
+    pub fn update(&mut self, m: &[u8]) {
+        match *self {
+            Polyval::Generic(ref mut g) => g.update(m),
+            Polyval::Platform(ref mut g) => g.update(m),
+        }
+    }
+
+    pub fn finalize(self) -> [u8; Self::TAG_LEN] {
+        match self {
+            Polyval::Generic(g) => g.finalize(),
+            Polyval::Platform(g) => g.finalize(),
+        }
+    }
+}

--- a/src/mac/polyval/mod.rs
+++ b/src/mac/polyval/mod.rs
@@ -1,23 +1,28 @@
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), all(target_feature = "sse2", target_feature = "pclmulqdq")))]
-#[path = "./x86.rs"]
-mod platform;
+use cfg_if::cfg_if;
 
-// NOTE:
-//      Crypto: AES + PMULL + SHA1 + SHA2
-//      https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L26
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto"))]
-#[path = "./aarch64.rs"]
-mod platform;
+cfg_if! {
+    if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
+                 all(target_feature = "sse2", target_feature = "pclmulqdq")))] {
+        mod x86;
+        pub use self::x86::Polyval;
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "crypto"))] {
+        mod aarch64;
+        pub use self::aarch64::Polyval;
+    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[path = "./x86.rs"]
+        mod platform;
 
+        #[cfg(target_arch = "aarch64")]
+        #[path = "./aarch64.rs"]
+        mod platform;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        all(target_feature = "sse2", target_feature = "pclmulqdq")
-    ),
-    all(target_arch = "aarch64", target_feature = "crypto")
-)))]
-#[path = "./generic.rs"]
-mod platform;
+        mod generic;
+        mod dynamic;
 
-pub use self::platform::Polyval;
+        pub use self::dynamic::Polyval;
+    } else {
+        mod generic;
+        pub use self::generic::Polyval;
+    }
+}

--- a/src/util/and.rs
+++ b/src/util/and.rs
@@ -1,43 +1,58 @@
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-#[cfg(target_arch = "aarch64")]
-use core::arch::aarch64::*;
 
+use cfg_if::cfg_if;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "sse2",
-    ),
-    target_arch = "aarch64",
-)))]
-pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+cfg_if! {
+    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+        fn and_si128_inplace_sse2(a: &mut [u8], b: &[u8]) {
+            unsafe {
+                let mut c = _mm_loadu_si128(a.as_ptr() as *const __m128i);
+                let d = _mm_loadu_si128(b.as_ptr() as *const __m128i);
+                c = _mm_and_si128(c, d);
+                _mm_storeu_si128(a.as_mut_ptr() as *mut __m128i, c);
+            }
+        }
+
+        #[cfg(target_feature = "sse2")]
+        #[inline]
+        pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+            and_si128_inplace_sse2(a, b)
+        }
+
+        #[cfg(not(target_feature = "sse2"))]
+        #[inline]
+        pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+            if std::is_x86_feature_detected!("sse2") {
+                and_si128_inplace_sse2(a, b)
+            } else {
+                and_si128_inplace_generic(a, b)
+            }
+        }
+    } else if #[cfg(target_arch = "aarch64")] {
+        pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+            unsafe {
+                let c: *mut uint8x16_t = a.as_mut_ptr() as *mut uint8x16_t;
+                let d: uint8x16_t = *(b.as_ptr() as *const uint8x16_t);
+
+                *c = vandq_u8(*c, d);
+            }
+        }
+    } else {
+        #[inline]
+        pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+            and_si128_inplace_generic(a, b)
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn and_si128_inplace_generic(a: &mut [u8], b: &[u8]) {
     for i in 0..16 {
         a[i] &= b[i]
-    }
-}
-
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    all(target_feature = "sse2"),
-))]
-pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
-    unsafe {
-        let mut c = _mm_loadu_si128(a.as_ptr() as *const __m128i);
-        let d = _mm_loadu_si128(b.as_ptr() as *const __m128i);
-        c = _mm_and_si128(c, d);
-        _mm_storeu_si128(a.as_mut_ptr() as *mut __m128i, c);
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
-    unsafe {
-        let c: *mut uint8x16_t = a.as_mut_ptr() as *mut uint8x16_t;
-        let d: uint8x16_t = *(b.as_ptr() as *const uint8x16_t);
-        
-        *c = vandq_u8(*c, d);
     }
 }

--- a/src/util/xor.rs
+++ b/src/util/xor.rs
@@ -1,49 +1,62 @@
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-#[cfg(target_arch = "aarch64")]
-use core::arch::aarch64::*;
 
+use cfg_if::cfg_if;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "sse2",
-    ),
-    target_arch = "aarch64",
-)))]
-pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+cfg_if! {
+    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+        pub fn xor_si128_inplace_sse2(a: &mut [u8], b: &[u8]) {
+            unsafe {
+                let mut c = _mm_loadu_si128(a.as_ptr() as *const __m128i);
+                let d = _mm_loadu_si128(b.as_ptr() as *const __m128i);
+                c = _mm_xor_si128(c, d);
+                _mm_storeu_si128(a.as_mut_ptr() as *mut __m128i, c);
+            }
+        }
+
+        #[cfg(target_feature = "sse2")]
+        #[inline]
+        pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+            xor_si128_inplace_sse2(a, b)
+        }
+
+        #[cfg(not(target_feature = "sse2"))]
+        #[inline]
+        pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+            if std::is_x86_feature_detected!("sse2") {
+                xor_si128_inplace_sse2(a, b)
+            } else {
+                xor_si128_inplace_generic(a, b)
+            }
+        }
+    } else if #[cfg(target_arch = "aarch64")] {
+        pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+            unsafe {
+                let c: *mut uint8x16_t = a.as_mut_ptr() as *mut uint8x16_t;
+                let d: uint8x16_t = *(b.as_ptr() as *const uint8x16_t);
+
+                *c = veorq_u8(*c, d);
+            }
+        }
+    } else {
+        #[inline]
+        pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+            xor_si128_inplace_generic(a, b)
+        }
+    }
+
+}
+
+#[allow(dead_code)]
+fn xor_si128_inplace_generic(a: &mut [u8], b: &[u8]) {
     for i in 0..16 {
         a[i] ^= b[i]
     }
 }
-
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    all(target_feature = "sse2"),
-))]
-pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
-    unsafe {
-        let mut c = _mm_loadu_si128(a.as_ptr() as *const __m128i);
-        let d = _mm_loadu_si128(b.as_ptr() as *const __m128i);
-        c = _mm_xor_si128(c, d);
-        _mm_storeu_si128(a.as_mut_ptr() as *mut __m128i, c);
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
-    unsafe {
-        let c: *mut uint8x16_t = a.as_mut_ptr() as *mut uint8x16_t;
-        let d: uint8x16_t = *(b.as_ptr() as *const uint8x16_t);
-        
-        *c = veorq_u8(*c, d);
-    }
-}
-
-
-
 
 // #[cfg(all(
 //     any(target_arch = "x86", target_arch = "x86_64"),
@@ -58,8 +71,6 @@ pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
 //     }
 // }
 
-
-
 // #[cfg(all(
 //     any(target_arch = "x86", target_arch = "x86_64"),
 //     all(target_feature = "avx512f"),
@@ -67,10 +78,10 @@ pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
 // pub fn xor_si512_inplace(a: &mut [u8], b: &[u8]) {
 //     // __m512i _mm512_loadu_si512 (void const* mem_addr)
 //     // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_loadu_si512&expand=101,97,100,6171,94,97,100,3420
-//     // 
+//     //
 //     // __m512i _mm512_xor_si512 (__m512i a, __m512i b)
 //     // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_xor_si512&expand=101,97,100,6171,94,97,100,3420,6172
-//     // 
+//     //
 //     // void _mm512_storeu_si512 (void* mem_addr, __m512i a)
 //     // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_storeu_si512&expand=101,97,100,6171,94,97,100,3420,5657
 //     unsafe {


### PR DESCRIPTION
When compile without required features, such as `aes` on x86, `crypto` on Aarch64, this PR will try to enable the optimization in the runtime.

If it is compiled with required features, then there will be exactly the same as the current implementation.