### PR TITLE
Enable optimization dynamically if target-feature is unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/crypto2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
+cfg-if = "1"
 
 [dev-dependencies]
 hex = "0.4"
@@ -23,7 +23,6 @@ default = [
 ]
 
 std     = [ ]
-nightly = [ ]
 openssh = [ ]
 
 

--- a/src/blockcipher/aes/dynamic.rs
+++ b/src/blockcipher/aes/dynamic.rs
@@ -1,0 +1,63 @@
+use std::fmt::{self, Debug};
+
+use super::generic;
+use super::platform;
+
+macro_rules! impl_dynamic_dispatch {
+    ($name:ident) => {
+        #[derive(Clone)]
+        pub enum $name {
+            Generic(generic::$name),
+            Platform(platform::$name),
+        }
+
+        impl Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match *self {
+                    $name::Generic(ref d) => Debug::fmt(d, f),
+                    $name::Platform(ref d) => Debug::fmt(d, f),
+                }
+            }
+        }
+
+        impl $name {
+            pub const KEY_LEN: usize = generic::$name::KEY_LEN;
+            pub const BLOCK_LEN: usize = generic::$name::BLOCK_LEN;
+
+            #[inline]
+            pub fn new(key: &[u8]) -> $name {
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                if std::is_x86_feature_detected!("aes") && std::is_x86_feature_detected!("sse2") {
+                    return $name::Platform(platform::$name::new(key));
+                }
+
+                #[cfg(target_arch = "aarch64")]
+                if std::is_aarch64_feature_detected!("aes") {
+                    return $name::Platform(platform::$name::new(key));
+                }
+
+                $name::Generic(generic::$name::new(key))
+            }
+
+            #[inline]
+            pub fn encrypt(&self, plaintext_in_ciphertext_out: &mut [u8]) {
+                match *self {
+                    $name::Generic(ref c) => c.encrypt(plaintext_in_ciphertext_out),
+                    $name::Platform(ref c) => c.encrypt(plaintext_in_ciphertext_out),
+                }
+            }
+
+            #[inline]
+            pub fn decrypt(&self, ciphertext_in_plaintext_out: &mut [u8]) {
+                match *self {
+                    $name::Generic(ref c) => c.decrypt(ciphertext_in_plaintext_out),
+                    $name::Platform(ref c) => c.decrypt(ciphertext_in_plaintext_out),
+                }
+            }
+        }
+    };
+}
+
+impl_dynamic_dispatch!(Aes128);
+impl_dynamic_dispatch!(Aes192);
+impl_dynamic_dispatch!(Aes256);

--- a/src/blockcipher/aes/mod.rs
+++ b/src/blockcipher/aes/mod.rs
@@ -1,48 +1,50 @@
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    all(target_feature = "aes", target_feature = "sse2")
-))]
-#[path = "./x86.rs"]
-mod platform;
+use cfg_if::cfg_if;
 
+cfg_if! {
+    if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
+                 all(target_feature = "aes", target_feature = "sse2")))] {
+        mod x86;
+        pub use self::x86::*;
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "crypto"))] {
+        // NOTE:
+        //      Crypto: AES + PMULL + SHA1 + SHA2
+        //      https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L26
+        mod aarch64;
+        pub use self::aarch64::*;
+    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {
+        // Check for platform specific optimizations dynamically
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[path = "./x86.rs"]
+        mod platform;
 
-// NOTE:
-//      Crypto: AES + PMULL + SHA1 + SHA2
-//      https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L26
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto"))]
-#[path = "./aarch64.rs"]
-mod platform;
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto"))]
-#[allow(dead_code)]
-mod generic;
+        #[cfg(target_arch = "aarch64")]
+        #[path = "./aarch64.rs"]
+        mod platform;
 
+        mod generic;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        all(target_feature = "aes", target_feature = "sse2")
-    ),
-    all(target_arch = "aarch64", target_feature = "crypto")
-)))]
-#[path = "./generic.rs"]
-mod platform;
-
-pub use self::platform::*;
-
-
+        mod dynamic;
+        pub use self::dynamic::*;
+    } else {
+        mod generic;
+        pub use self::generic::*;
+    }
+}
 
 #[test]
 fn test_aes128() {
     // AES 128
     let key = hex::decode("000102030405060708090a0b0c0d0e0f").unwrap();
     let plaintext = hex::decode("00112233445566778899aabbccddeeff").unwrap();
-    
+
     let cipher = Aes128::new(&key);
 
     let mut ciphertext = plaintext.clone();
     cipher.encrypt(&mut ciphertext);
-    assert_eq!(&ciphertext[..],
-        &hex::decode("69c4e0d86a7b0430d8cdb78070b4c55a").unwrap()[..]);
+    assert_eq!(
+        &ciphertext[..],
+        &hex::decode("69c4e0d86a7b0430d8cdb78070b4c55a").unwrap()[..]
+    );
 
     let mut cleartext = ciphertext.clone();
     cipher.decrypt(&mut cleartext);
@@ -53,13 +55,15 @@ fn test_aes128() {
 fn test_aes192() {
     let key = hex::decode("000102030405060708090a0b0c0d0e0f1011121314151617").unwrap();
     let plaintext = hex::decode("00112233445566778899aabbccddeeff").unwrap();
-    
+
     let cipher = Aes192::new(&key);
-    
+
     let mut ciphertext = plaintext.clone();
     cipher.encrypt(&mut ciphertext);
-    assert_eq!(&ciphertext[..],
-        &hex::decode("dda97ca4864cdfe06eaf70a0ec0d7191").unwrap()[..]);
+    assert_eq!(
+        &ciphertext[..],
+        &hex::decode("dda97ca4864cdfe06eaf70a0ec0d7191").unwrap()[..]
+    );
 
     let mut cleartext = ciphertext.clone();
     cipher.decrypt(&mut cleartext);
@@ -69,15 +73,18 @@ fn test_aes192() {
 #[test]
 fn test_aes256() {
     // AES 256
-    let key = hex::decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f").unwrap();
+    let key =
+        hex::decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f").unwrap();
     let plaintext = hex::decode("00112233445566778899aabbccddeeff").unwrap();
-    
+
     let cipher = Aes256::new(&key);
 
     let mut ciphertext = plaintext.clone();
     cipher.encrypt(&mut ciphertext);
-    assert_eq!(&ciphertext[..],
-        &hex::decode("8ea2b7ca516745bfeafc49904b496089").unwrap()[..]);
+    assert_eq!(
+        &ciphertext[..],
+        &hex::decode("8ea2b7ca516745bfeafc49904b496089").unwrap()[..]
+    );
 
     let mut cleartext = ciphertext.clone();
     cipher.decrypt(&mut cleartext);

--- a/src/blockcipher/aes/mod.rs
+++ b/src/blockcipher/aes/mod.rs
@@ -1,27 +1,34 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
-                 all(target_feature = "aes", target_feature = "sse2")))] {
-        mod x86;
-        pub use self::x86::*;
-    } else if #[cfg(all(target_arch = "aarch64", target_feature = "aes"))] {
-        mod aarch64;
-        pub use self::aarch64::*;
-    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {
-        // Check for platform specific optimizations dynamically
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
         #[path = "./x86.rs"]
         mod platform;
 
-        #[cfg(target_arch = "aarch64")]
+        cfg_if! {
+            if #[cfg(all(target_feature = "aes", target_feature = "sse2"))] {
+                pub use self::platform::*;
+            } else {
+                mod generic;
+                mod dynamic;
+
+                pub use self::dynamic::*;
+            }
+        }
+    } else if #[cfg(target_arch = "aarch64")] {
         #[path = "./aarch64.rs"]
         mod platform;
-
         mod generic;
 
-        mod dynamic;
-        pub use self::dynamic::*;
+        cfg_if! {
+            if #[cfg(target_feature = "aes")] {
+                pub use self::platform::*;
+            } else {
+                mod dynamic;
+
+                pub use self::dynamic::*;
+            }
+        }
     } else {
         mod generic;
         pub use self::generic::*;

--- a/src/blockcipher/aes/mod.rs
+++ b/src/blockcipher/aes/mod.rs
@@ -5,10 +5,7 @@ cfg_if! {
                  all(target_feature = "aes", target_feature = "sse2")))] {
         mod x86;
         pub use self::x86::*;
-    } else if #[cfg(all(target_arch = "aarch64", target_feature = "crypto"))] {
-        // NOTE:
-        //      Crypto: AES + PMULL + SHA1 + SHA2
-        //      https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L26
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "aes"))] {
         mod aarch64;
         pub use self::aarch64::*;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {

--- a/src/blockcipher/aes/x86.rs
+++ b/src/blockcipher/aes/x86.rs
@@ -32,76 +32,88 @@ impl Aes128 {
     pub const BLOCK_LEN: usize = 16;
     pub const KEY_LEN: usize   = 16;
 
+    #[inline(always)]
     pub fn new(key: &[u8]) -> Self {
+        unsafe { Self::new_simd(key) }
+    }
+
+    #[target_feature(enable = "sse2,aes")]
+    unsafe fn new_simd(key: &[u8]) -> Self {
         assert_eq!(key.len(), Self::KEY_LEN);
 
-        unsafe {
-            let mut ek: [__m128i; 20] = core::mem::zeroed();
+        let mut ek: [__m128i; 20] = core::mem::zeroed();
 
-            ek[0] = _mm_loadu_si128(key.as_ptr() as *const __m128i);
-            aes128_keyround!(ek,  1, 0x01);
-            aes128_keyround!(ek,  2, 0x02);
-            aes128_keyround!(ek,  3, 0x04);
-            aes128_keyround!(ek,  4, 0x08);
-            aes128_keyround!(ek,  5, 0x10);
-            aes128_keyround!(ek,  6, 0x20);
-            aes128_keyround!(ek,  7, 0x40);
-            aes128_keyround!(ek,  8, 0x80);
-            aes128_keyround!(ek,  9, 0x1b);
-            aes128_keyround!(ek, 10, 0x36);
+        ek[0] = _mm_loadu_si128(key.as_ptr() as *const __m128i);
+        aes128_keyround!(ek,  1, 0x01);
+        aes128_keyround!(ek,  2, 0x02);
+        aes128_keyround!(ek,  3, 0x04);
+        aes128_keyround!(ek,  4, 0x08);
+        aes128_keyround!(ek,  5, 0x10);
+        aes128_keyround!(ek,  6, 0x20);
+        aes128_keyround!(ek,  7, 0x40);
+        aes128_keyround!(ek,  8, 0x80);
+        aes128_keyround!(ek,  9, 0x1b);
+        aes128_keyround!(ek, 10, 0x36);
 
-            ek[11] = _mm_aesimc_si128(ek[9]);
-            ek[12] = _mm_aesimc_si128(ek[8]);
-            ek[13] = _mm_aesimc_si128(ek[7]);
-            ek[14] = _mm_aesimc_si128(ek[6]);
-            ek[15] = _mm_aesimc_si128(ek[5]);
-            ek[16] = _mm_aesimc_si128(ek[4]);
-            ek[17] = _mm_aesimc_si128(ek[3]);
-            ek[18] = _mm_aesimc_si128(ek[2]);
-            ek[19] = _mm_aesimc_si128(ek[1]);
+        ek[11] = _mm_aesimc_si128(ek[9]);
+        ek[12] = _mm_aesimc_si128(ek[8]);
+        ek[13] = _mm_aesimc_si128(ek[7]);
+        ek[14] = _mm_aesimc_si128(ek[6]);
+        ek[15] = _mm_aesimc_si128(ek[5]);
+        ek[16] = _mm_aesimc_si128(ek[4]);
+        ek[17] = _mm_aesimc_si128(ek[3]);
+        ek[18] = _mm_aesimc_si128(ek[2]);
+        ek[19] = _mm_aesimc_si128(ek[1]);
 
-            Self { ek }
-        }
+        Self { ek }
     }
-    
+
+    #[inline(always)]
     pub fn encrypt(&self, block: &mut [u8]) {
-        debug_assert_eq!(block.len(), Self::BLOCK_LEN);
-
-        unsafe {
-            let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
-            m =        _mm_xor_si128(m, self.ek[ 0]);
-            m =     _mm_aesenc_si128(m, self.ek[ 1]);
-            m =     _mm_aesenc_si128(m, self.ek[ 2]);
-            m =     _mm_aesenc_si128(m, self.ek[ 3]);
-            m =     _mm_aesenc_si128(m, self.ek[ 4]);
-            m =     _mm_aesenc_si128(m, self.ek[ 5]);
-            m =     _mm_aesenc_si128(m, self.ek[ 6]);
-            m =     _mm_aesenc_si128(m, self.ek[ 7]);
-            m =     _mm_aesenc_si128(m, self.ek[ 8]);
-            m =     _mm_aesenc_si128(m, self.ek[ 9]);
-            m = _mm_aesenclast_si128(m, self.ek[10]);
-            _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
-        }
+        unsafe { self.encrypt_simd(block) }
     }
 
-    pub fn decrypt(&self, block: &mut [u8]) {
+    #[target_feature(enable = "sse2,aes")]
+    unsafe fn encrypt_simd(&self, block: &mut [u8]) {
         debug_assert_eq!(block.len(), Self::BLOCK_LEN);
 
-        unsafe {
-            let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
-            m =        _mm_xor_si128(m, self.ek[10]);
-            m =     _mm_aesdec_si128(m, self.ek[11]);
-            m =     _mm_aesdec_si128(m, self.ek[12]);
-            m =     _mm_aesdec_si128(m, self.ek[13]);
-            m =     _mm_aesdec_si128(m, self.ek[14]);
-            m =     _mm_aesdec_si128(m, self.ek[15]);
-            m =     _mm_aesdec_si128(m, self.ek[16]);
-            m =     _mm_aesdec_si128(m, self.ek[17]);
-            m =     _mm_aesdec_si128(m, self.ek[18]);
-            m =     _mm_aesdec_si128(m, self.ek[19]);
-            m = _mm_aesdeclast_si128(m, self.ek[ 0]);
-            _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
-        }
+        let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+        m =        _mm_xor_si128(m, self.ek[ 0]);
+        m =     _mm_aesenc_si128(m, self.ek[ 1]);
+        m =     _mm_aesenc_si128(m, self.ek[ 2]);
+        m =     _mm_aesenc_si128(m, self.ek[ 3]);
+        m =     _mm_aesenc_si128(m, self.ek[ 4]);
+        m =     _mm_aesenc_si128(m, self.ek[ 5]);
+        m =     _mm_aesenc_si128(m, self.ek[ 6]);
+        m =     _mm_aesenc_si128(m, self.ek[ 7]);
+        m =     _mm_aesenc_si128(m, self.ek[ 8]);
+        m =     _mm_aesenc_si128(m, self.ek[ 9]);
+        m = _mm_aesenclast_si128(m, self.ek[10]);
+        _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
+    }
+
+    #[inline(always)]
+    pub fn decrypt(&self, block: &mut [u8]) {
+        unsafe { self.decrypt_simd(block) }
+    }
+
+    #[target_feature(enable = "sse2,aes")]
+    unsafe fn decrypt_simd(&self, block: &mut [u8]) {
+        debug_assert_eq!(block.len(), Self::BLOCK_LEN);
+
+        let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+        m =        _mm_xor_si128(m, self.ek[10]);
+        m =     _mm_aesdec_si128(m, self.ek[11]);
+        m =     _mm_aesdec_si128(m, self.ek[12]);
+        m =     _mm_aesdec_si128(m, self.ek[13]);
+        m =     _mm_aesdec_si128(m, self.ek[14]);
+        m =     _mm_aesdec_si128(m, self.ek[15]);
+        m =     _mm_aesdec_si128(m, self.ek[16]);
+        m =     _mm_aesdec_si128(m, self.ek[17]);
+        m =     _mm_aesdec_si128(m, self.ek[18]);
+        m =     _mm_aesdec_si128(m, self.ek[19]);
+        m = _mm_aesdeclast_si128(m, self.ek[ 0]);
+        _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
     }
 }
 
@@ -141,122 +153,134 @@ impl Aes192 {
     pub const BLOCK_LEN: usize = 16;
     pub const KEY_LEN: usize   = 24;
 
+    #[inline(always)]
     pub fn new(key: &[u8]) -> Self {
+        unsafe { Self::new_simd(key) }
+    }
+
+    #[target_feature(enable = "sse2,aes")]
+    unsafe fn new_simd(key: &[u8]) -> Self {
         assert_eq!(key.len(), Self::KEY_LEN);
 
         use core::mem::transmute;
 
-        unsafe {
-            let mut ek: [__m128i; 24] = core::mem::zeroed();
+        let mut ek: [__m128i; 24] = core::mem::zeroed();
 
-            let mut k2 = [0u8; 16];
-            k2[0..8].copy_from_slice(&key[16..24]);
+        let mut k2 = [0u8; 16];
+        k2[0..8].copy_from_slice(&key[16..24]);
 
-            let mut temp1 = _mm_loadu_si128(key.as_ptr() as *const __m128i);
-            let mut temp2: __m128i = core::mem::zeroed();
-            let mut temp3 = _mm_loadu_si128(k2.as_ptr() as *const __m128i);
-            
-            ek[0] = temp1;
-            ek[1] = temp3;
+        let mut temp1 = _mm_loadu_si128(key.as_ptr() as *const __m128i);
+        let mut temp2: __m128i = core::mem::zeroed();
+        let mut temp3 = _mm_loadu_si128(k2.as_ptr() as *const __m128i);
+        
+        ek[0] = temp1;
+        ek[1] = temp3;
 
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x1);
-            aes192_keyround!(temp1, temp2, temp3);
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x1);
+        aes192_keyround!(temp1, temp2, temp3);
 
-            ek[1] = transmute(_mm_shuffle_pd(transmute(ek[1]), transmute(temp1), 0));
-            ek[2] = transmute(_mm_shuffle_pd(transmute(temp1), transmute(temp3), 1));
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x2);
-            aes192_keyround!(temp1, temp2, temp3);
-            
-            ek[3] = temp1;
-            ek[4] = temp3;
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x4);
-            aes192_keyround!(temp1, temp2, temp3);
+        ek[1] = transmute(_mm_shuffle_pd(transmute(ek[1]), transmute(temp1), 0));
+        ek[2] = transmute(_mm_shuffle_pd(transmute(temp1), transmute(temp3), 1));
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x2);
+        aes192_keyround!(temp1, temp2, temp3);
+        
+        ek[3] = temp1;
+        ek[4] = temp3;
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x4);
+        aes192_keyround!(temp1, temp2, temp3);
 
-            ek[4] = transmute(_mm_shuffle_pd(transmute(ek[4]), transmute(temp1), 0));
-            ek[5] = transmute(_mm_shuffle_pd(transmute(temp1), transmute(temp3), 1));
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x8);
-            aes192_keyround!(temp1, temp2, temp3);
+        ek[4] = transmute(_mm_shuffle_pd(transmute(ek[4]), transmute(temp1), 0));
+        ek[5] = transmute(_mm_shuffle_pd(transmute(temp1), transmute(temp3), 1));
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x8);
+        aes192_keyround!(temp1, temp2, temp3);
 
-            ek[6] = temp1;
-            ek[7] = temp3;
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x10);
-            aes192_keyround!(temp1, temp2, temp3);
+        ek[6] = temp1;
+        ek[7] = temp3;
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x10);
+        aes192_keyround!(temp1, temp2, temp3);
 
-            ek[7] = transmute(_mm_shuffle_pd(transmute(ek[7]), transmute(temp1), 0));
-            ek[8] = transmute(_mm_shuffle_pd(transmute(temp1), transmute(temp3), 1));
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x20);
-            aes192_keyround!(temp1, temp2, temp3);
+        ek[7] = transmute(_mm_shuffle_pd(transmute(ek[7]), transmute(temp1), 0));
+        ek[8] = transmute(_mm_shuffle_pd(transmute(temp1), transmute(temp3), 1));
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x20);
+        aes192_keyround!(temp1, temp2, temp3);
 
-            ek[ 9] = temp1;
-            ek[10] = temp3;
-            temp2  = _mm_aeskeygenassist_si128(temp3, 0x40);
-            aes192_keyround!(temp1, temp2, temp3);
+        ek[ 9] = temp1;
+        ek[10] = temp3;
+        temp2  = _mm_aeskeygenassist_si128(temp3, 0x40);
+        aes192_keyround!(temp1, temp2, temp3);
 
-            ek[10] = transmute(_mm_shuffle_pd(transmute(ek[10]), transmute(temp1), 0));
-            ek[11] = transmute(_mm_shuffle_pd(transmute(temp1), transmute(temp3), 1));
-            temp2  = _mm_aeskeygenassist_si128(temp3, 0x80);
-            aes192_keyround!(temp1, temp2, temp3);
+        ek[10] = transmute(_mm_shuffle_pd(transmute(ek[10]), transmute(temp1), 0));
+        ek[11] = transmute(_mm_shuffle_pd(transmute(temp1), transmute(temp3), 1));
+        temp2  = _mm_aeskeygenassist_si128(temp3, 0x80);
+        aes192_keyround!(temp1, temp2, temp3);
 
-            ek[12] = temp1;
+        ek[12] = temp1;
 
-            ek[13] = _mm_aesimc_si128(ek[11]);
-            ek[14] = _mm_aesimc_si128(ek[10]);
-            ek[15] = _mm_aesimc_si128(ek[ 9]);
-            ek[16] = _mm_aesimc_si128(ek[ 8]);
-            ek[17] = _mm_aesimc_si128(ek[ 7]);
-            ek[18] = _mm_aesimc_si128(ek[ 6]);
-            ek[19] = _mm_aesimc_si128(ek[ 5]);
-            ek[20] = _mm_aesimc_si128(ek[ 4]);
-            ek[21] = _mm_aesimc_si128(ek[ 3]);
-            ek[22] = _mm_aesimc_si128(ek[ 2]);
-            ek[23] = _mm_aesimc_si128(ek[ 1]);
+        ek[13] = _mm_aesimc_si128(ek[11]);
+        ek[14] = _mm_aesimc_si128(ek[10]);
+        ek[15] = _mm_aesimc_si128(ek[ 9]);
+        ek[16] = _mm_aesimc_si128(ek[ 8]);
+        ek[17] = _mm_aesimc_si128(ek[ 7]);
+        ek[18] = _mm_aesimc_si128(ek[ 6]);
+        ek[19] = _mm_aesimc_si128(ek[ 5]);
+        ek[20] = _mm_aesimc_si128(ek[ 4]);
+        ek[21] = _mm_aesimc_si128(ek[ 3]);
+        ek[22] = _mm_aesimc_si128(ek[ 2]);
+        ek[23] = _mm_aesimc_si128(ek[ 1]);
 
-            Self { ek }
-        }
+        Self { ek }
     }
-    
+
+    #[inline(always)]
     pub fn encrypt(&self, block: &mut [u8]) {
-        debug_assert_eq!(block.len(), Self::BLOCK_LEN);
-
-        unsafe {
-            let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
-            m =        _mm_xor_si128(m, self.ek[ 0]);
-            m =     _mm_aesenc_si128(m, self.ek[ 1]);
-            m =     _mm_aesenc_si128(m, self.ek[ 2]);
-            m =     _mm_aesenc_si128(m, self.ek[ 3]);
-            m =     _mm_aesenc_si128(m, self.ek[ 4]);
-            m =     _mm_aesenc_si128(m, self.ek[ 5]);
-            m =     _mm_aesenc_si128(m, self.ek[ 6]);
-            m =     _mm_aesenc_si128(m, self.ek[ 7]);
-            m =     _mm_aesenc_si128(m, self.ek[ 8]);
-            m =     _mm_aesenc_si128(m, self.ek[ 9]);
-            m =     _mm_aesenc_si128(m, self.ek[10]);
-            m =     _mm_aesenc_si128(m, self.ek[11]);
-            m =     _mm_aesenclast_si128(m, self.ek[12]);
-            _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
-        }
+        unsafe { self.encrypt_simd(block) }
     }
 
-    pub fn decrypt(&self, block: &mut [u8]) {
+    #[target_feature(enable = "sse2,aes")]
+    unsafe fn encrypt_simd(&self, block: &mut [u8]) {
         debug_assert_eq!(block.len(), Self::BLOCK_LEN);
 
-        unsafe {
-            let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
-            m =        _mm_xor_si128(m, self.ek[12]);
-            m =     _mm_aesdec_si128(m, self.ek[13]);
-            m =     _mm_aesdec_si128(m, self.ek[14]);
-            m =     _mm_aesdec_si128(m, self.ek[15]);
-            m =     _mm_aesdec_si128(m, self.ek[16]);
-            m =     _mm_aesdec_si128(m, self.ek[17]);
-            m =     _mm_aesdec_si128(m, self.ek[18]);
-            m =     _mm_aesdec_si128(m, self.ek[19]);
-            m =     _mm_aesdec_si128(m, self.ek[20]);
-            m =     _mm_aesdec_si128(m, self.ek[21]);
-            m =     _mm_aesdec_si128(m, self.ek[22]);
-            m =     _mm_aesdec_si128(m, self.ek[23]);
-            m =     _mm_aesdeclast_si128(m, self.ek[ 0]);
-            _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
-        }
+        let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+        m =        _mm_xor_si128(m, self.ek[ 0]);
+        m =     _mm_aesenc_si128(m, self.ek[ 1]);
+        m =     _mm_aesenc_si128(m, self.ek[ 2]);
+        m =     _mm_aesenc_si128(m, self.ek[ 3]);
+        m =     _mm_aesenc_si128(m, self.ek[ 4]);
+        m =     _mm_aesenc_si128(m, self.ek[ 5]);
+        m =     _mm_aesenc_si128(m, self.ek[ 6]);
+        m =     _mm_aesenc_si128(m, self.ek[ 7]);
+        m =     _mm_aesenc_si128(m, self.ek[ 8]);
+        m =     _mm_aesenc_si128(m, self.ek[ 9]);
+        m =     _mm_aesenc_si128(m, self.ek[10]);
+        m =     _mm_aesenc_si128(m, self.ek[11]);
+        m =     _mm_aesenclast_si128(m, self.ek[12]);
+        _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
+    }
+
+    #[inline(always)]
+    pub fn decrypt(&self, block: &mut [u8]) {
+        unsafe { self.decrypt_simd(block) }
+    }
+
+    #[target_feature(enable = "sse2,aes")]
+    unsafe fn decrypt_simd(&self, block: &mut [u8]) {
+        debug_assert_eq!(block.len(), Self::BLOCK_LEN);
+
+        let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+        m =        _mm_xor_si128(m, self.ek[12]);
+        m =     _mm_aesdec_si128(m, self.ek[13]);
+        m =     _mm_aesdec_si128(m, self.ek[14]);
+        m =     _mm_aesdec_si128(m, self.ek[15]);
+        m =     _mm_aesdec_si128(m, self.ek[16]);
+        m =     _mm_aesdec_si128(m, self.ek[17]);
+        m =     _mm_aesdec_si128(m, self.ek[18]);
+        m =     _mm_aesdec_si128(m, self.ek[19]);
+        m =     _mm_aesdec_si128(m, self.ek[20]);
+        m =     _mm_aesdec_si128(m, self.ek[21]);
+        m =     _mm_aesdec_si128(m, self.ek[22]);
+        m =     _mm_aesdec_si128(m, self.ek[23]);
+        m =     _mm_aesdeclast_si128(m, self.ek[ 0]);
+        _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
     }
 }
 
@@ -308,123 +332,135 @@ impl Aes256 {
     pub const BLOCK_LEN: usize = 16;
     pub const KEY_LEN: usize   = 32;
 
+    #[inline(always)]
     pub fn new(key: &[u8]) -> Self {
+        unsafe { Self::new_simd(key) }
+    }
+
+    #[target_feature(enable = "sse2,aes")]
+    unsafe fn new_simd(key: &[u8]) -> Self {
         assert_eq!(key.len(), Self::KEY_LEN);
 
-        unsafe {
-            let mut ek: [__m128i; 28] = core::mem::zeroed();
+        let mut ek: [__m128i; 28] = core::mem::zeroed();
 
-            let mut temp1 = _mm_loadu_si128(key.as_ptr() as *const __m128i);
-            let mut temp2: __m128i = core::mem::zeroed();
-            let mut temp3 = _mm_loadu_si128(key.as_ptr().offset(16) as *const __m128i);
+        let mut temp1 = _mm_loadu_si128(key.as_ptr() as *const __m128i);
+        let mut temp2: __m128i = core::mem::zeroed();
+        let mut temp3 = _mm_loadu_si128(key.as_ptr().offset(16) as *const __m128i);
 
-            ek[0] = temp1;
-            ek[1] = temp3;
+        ek[0] = temp1;
+        ek[1] = temp3;
 
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x1);
-            aes256_keyround_1!(temp1, temp2);
-            ek[2] = temp1;
-            aes256_keyround_2!(temp1, temp3);
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x1);
+        aes256_keyround_1!(temp1, temp2);
+        ek[2] = temp1;
+        aes256_keyround_2!(temp1, temp3);
 
-            ek[3] = temp3;
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x02);
-            aes256_keyround_1!(temp1, temp2);
-            ek[4] = temp1;
-            aes256_keyround_2!(temp1, temp3);
-        
-            ek[5] = temp3;
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x04);
-            aes256_keyround_1!(temp1, temp2);
-            ek[6] = temp1;
-            aes256_keyround_2!(temp1, temp3);
-
-            ek[7] = temp3;
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x08);
-            aes256_keyround_1!(temp1, temp2);
-            ek[8] = temp1;
-            aes256_keyround_2!(temp1, temp3);
-
-            ek[9] = temp3;
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x10);
-            aes256_keyround_1!(temp1, temp2);
-            ek[10] = temp1;
-            aes256_keyround_2!(temp1, temp3);
-
-            ek[11] = temp3;
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x20);
-            aes256_keyround_1!(temp1, temp2);
-            ek[12] = temp1;
-            aes256_keyround_2!(temp1, temp3);
-
-            ek[13] = temp3;
-            temp2 = _mm_aeskeygenassist_si128(temp3, 0x40);
-            aes256_keyround_1!(temp1, temp2);
-            ek[14] = temp1;
-
-            ek[15] = _mm_aesimc_si128(ek[13]);
-            ek[16] = _mm_aesimc_si128(ek[12]);
-            ek[17] = _mm_aesimc_si128(ek[11]);
-            ek[18] = _mm_aesimc_si128(ek[10]);
-            ek[19] = _mm_aesimc_si128(ek[ 9]);
-            ek[20] = _mm_aesimc_si128(ek[ 8]);
-            ek[21] = _mm_aesimc_si128(ek[ 7]);
-            ek[22] = _mm_aesimc_si128(ek[ 6]);
-            ek[23] = _mm_aesimc_si128(ek[ 5]);
-            ek[24] = _mm_aesimc_si128(ek[ 4]);
-            ek[25] = _mm_aesimc_si128(ek[ 3]);
-            ek[26] = _mm_aesimc_si128(ek[ 2]);
-            ek[27] = _mm_aesimc_si128(ek[ 1]);
-
-            Self { ek }
-        }
-    }
+        ek[3] = temp3;
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x02);
+        aes256_keyround_1!(temp1, temp2);
+        ek[4] = temp1;
+        aes256_keyround_2!(temp1, temp3);
     
-    pub fn encrypt(&self, block: &mut [u8]) {
-        debug_assert_eq!(block.len(), Self::BLOCK_LEN);
+        ek[5] = temp3;
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x04);
+        aes256_keyround_1!(temp1, temp2);
+        ek[6] = temp1;
+        aes256_keyround_2!(temp1, temp3);
 
-        unsafe {
-            let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
-            m =        _mm_xor_si128(m, self.ek[ 0]);
-            m =     _mm_aesenc_si128(m, self.ek[ 1]);
-            m =     _mm_aesenc_si128(m, self.ek[ 2]);
-            m =     _mm_aesenc_si128(m, self.ek[ 3]);
-            m =     _mm_aesenc_si128(m, self.ek[ 4]);
-            m =     _mm_aesenc_si128(m, self.ek[ 5]);
-            m =     _mm_aesenc_si128(m, self.ek[ 6]);
-            m =     _mm_aesenc_si128(m, self.ek[ 7]);
-            m =     _mm_aesenc_si128(m, self.ek[ 8]);
-            m =     _mm_aesenc_si128(m, self.ek[ 9]);
-            m =     _mm_aesenc_si128(m, self.ek[10]);
-            m =     _mm_aesenc_si128(m, self.ek[11]);
-            m =     _mm_aesenc_si128(m, self.ek[12]);
-            m =     _mm_aesenc_si128(m, self.ek[13]);
-            m =     _mm_aesenclast_si128(m, self.ek[14]);
-            _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
-        }
+        ek[7] = temp3;
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x08);
+        aes256_keyround_1!(temp1, temp2);
+        ek[8] = temp1;
+        aes256_keyround_2!(temp1, temp3);
+
+        ek[9] = temp3;
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x10);
+        aes256_keyround_1!(temp1, temp2);
+        ek[10] = temp1;
+        aes256_keyround_2!(temp1, temp3);
+
+        ek[11] = temp3;
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x20);
+        aes256_keyround_1!(temp1, temp2);
+        ek[12] = temp1;
+        aes256_keyround_2!(temp1, temp3);
+
+        ek[13] = temp3;
+        temp2 = _mm_aeskeygenassist_si128(temp3, 0x40);
+        aes256_keyround_1!(temp1, temp2);
+        ek[14] = temp1;
+
+        ek[15] = _mm_aesimc_si128(ek[13]);
+        ek[16] = _mm_aesimc_si128(ek[12]);
+        ek[17] = _mm_aesimc_si128(ek[11]);
+        ek[18] = _mm_aesimc_si128(ek[10]);
+        ek[19] = _mm_aesimc_si128(ek[ 9]);
+        ek[20] = _mm_aesimc_si128(ek[ 8]);
+        ek[21] = _mm_aesimc_si128(ek[ 7]);
+        ek[22] = _mm_aesimc_si128(ek[ 6]);
+        ek[23] = _mm_aesimc_si128(ek[ 5]);
+        ek[24] = _mm_aesimc_si128(ek[ 4]);
+        ek[25] = _mm_aesimc_si128(ek[ 3]);
+        ek[26] = _mm_aesimc_si128(ek[ 2]);
+        ek[27] = _mm_aesimc_si128(ek[ 1]);
+
+        Self { ek }
     }
 
+    #[inline(always)]
+    pub fn encrypt(&self, block: &mut [u8]) {
+        unsafe { self.encrypt_simd(block) }
+    }
+
+    #[target_feature(enable = "sse2,aes")]
+    unsafe fn encrypt_simd(&self, block: &mut [u8]) {
+        debug_assert_eq!(block.len(), Self::BLOCK_LEN);
+
+        let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+        m =        _mm_xor_si128(m, self.ek[ 0]);
+        m =     _mm_aesenc_si128(m, self.ek[ 1]);
+        m =     _mm_aesenc_si128(m, self.ek[ 2]);
+        m =     _mm_aesenc_si128(m, self.ek[ 3]);
+        m =     _mm_aesenc_si128(m, self.ek[ 4]);
+        m =     _mm_aesenc_si128(m, self.ek[ 5]);
+        m =     _mm_aesenc_si128(m, self.ek[ 6]);
+        m =     _mm_aesenc_si128(m, self.ek[ 7]);
+        m =     _mm_aesenc_si128(m, self.ek[ 8]);
+        m =     _mm_aesenc_si128(m, self.ek[ 9]);
+        m =     _mm_aesenc_si128(m, self.ek[10]);
+        m =     _mm_aesenc_si128(m, self.ek[11]);
+        m =     _mm_aesenc_si128(m, self.ek[12]);
+        m =     _mm_aesenc_si128(m, self.ek[13]);
+        m =     _mm_aesenclast_si128(m, self.ek[14]);
+        _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
+    }
+
+    #[inline(always)]
     pub fn decrypt(&self, block: &mut [u8]) {
+        unsafe { self.decrypt_simd(block) }
+    }
+
+    #[target_feature(enable = "sse2,aes")]
+    unsafe fn decrypt_simd(&self, block: &mut [u8]) {
         debug_assert_eq!(block.len(), Self::BLOCK_LEN);
         
-        unsafe {
-            let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
-            m =        _mm_xor_si128(m, self.ek[14]);
-            m =     _mm_aesdec_si128(m, self.ek[15]);
-            m =     _mm_aesdec_si128(m, self.ek[16]);
-            m =     _mm_aesdec_si128(m, self.ek[17]);
-            m =     _mm_aesdec_si128(m, self.ek[18]);
-            m =     _mm_aesdec_si128(m, self.ek[19]);
-            m =     _mm_aesdec_si128(m, self.ek[20]);
-            m =     _mm_aesdec_si128(m, self.ek[21]);
-            m =     _mm_aesdec_si128(m, self.ek[22]);
-            m =     _mm_aesdec_si128(m, self.ek[23]);
-            m =     _mm_aesdec_si128(m, self.ek[24]);
-            m =     _mm_aesdec_si128(m, self.ek[25]);
-            m =     _mm_aesdec_si128(m, self.ek[26]);
-            m =     _mm_aesdec_si128(m, self.ek[27]);
-            m =     _mm_aesdeclast_si128(m, self.ek[0]);
-            _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
-        }
+        let mut m = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+        m =        _mm_xor_si128(m, self.ek[14]);
+        m =     _mm_aesdec_si128(m, self.ek[15]);
+        m =     _mm_aesdec_si128(m, self.ek[16]);
+        m =     _mm_aesdec_si128(m, self.ek[17]);
+        m =     _mm_aesdec_si128(m, self.ek[18]);
+        m =     _mm_aesdec_si128(m, self.ek[19]);
+        m =     _mm_aesdec_si128(m, self.ek[20]);
+        m =     _mm_aesdec_si128(m, self.ek[21]);
+        m =     _mm_aesdec_si128(m, self.ek[22]);
+        m =     _mm_aesdec_si128(m, self.ek[23]);
+        m =     _mm_aesdec_si128(m, self.ek[24]);
+        m =     _mm_aesdec_si128(m, self.ek[25]);
+        m =     _mm_aesdec_si128(m, self.ek[26]);
+        m =     _mm_aesdec_si128(m, self.ek[27]);
+        m =     _mm_aesdeclast_si128(m, self.ek[0]);
+        _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, m);
     }
 }
 

--- a/src/hash/sha2/sha256/aarch64.rs
+++ b/src/hash/sha2/sha256/aarch64.rs
@@ -4,9 +4,13 @@ use super::Sha256;
 
 use core::arch::aarch64::*;
 
-
-#[inline]
+#[inline(always)]
 pub fn transform(state: &mut [u32; 8], block: &[u8]) {
+    unsafe { transform_simd(state, block) }
+}
+
+#[target_feature(enable = "sha2")]
+unsafe fn transform_simd(state: &mut [u32; 8], block: &[u8]) {
     // Process a block with the SHA-256 algorithm.
     // https://github.com/noloader/SHA-Intrinsics/blob/master/sha256-arm.c
     debug_assert_eq!(state.len(), 8);

--- a/src/hash/sha2/sha256/x86.rs
+++ b/src/hash/sha2/sha256/x86.rs
@@ -11,8 +11,13 @@ use core::arch::x86_64::*;
 // CHAPTER 8 INTEL® SHA EXTENSIONS
 // https://software.intel.com/sites/default/files/managed/07/b7/319433-023.pdf
 
-#[inline]
+#[inline(always)]
 pub fn transform(state: &mut [u32; 8], block: &[u8]) {
+    unsafe { transform_simd(state, block) }
+}
+
+#[target_feature(enable = "sha")]
+unsafe fn transform_simd(state: &mut [u32; 8], block: &[u8]) {
     // https://docs.rs/sha2ni/0.8.5/src/sha2ni/sha256_intrinsics.rs.html
     // 
     // Process a block with the SHA-256 algorithm.
@@ -20,203 +25,201 @@ pub fn transform(state: &mut [u32; 8], block: &[u8]) {
     debug_assert_eq!(state.len(), 8);
     debug_assert_eq!(block.len(), Sha256::BLOCK_LEN);
 
-    unsafe {
-        let mut state0: __m128i;
-        let mut state1: __m128i;
+    let mut state0: __m128i;
+    let mut state1: __m128i;
 
-        let mut msg: __m128i;
-        let mut tmp: __m128i;
+    let mut msg: __m128i;
+    let mut tmp: __m128i;
 
-        let mut msg0: __m128i;
-        let mut msg1: __m128i;
-        let mut msg2: __m128i;
-        let mut msg3: __m128i;
+    let mut msg0: __m128i;
+    let mut msg1: __m128i;
+    let mut msg2: __m128i;
+    let mut msg3: __m128i;
 
-        let abef_save: __m128i;
-        let cdgh_save: __m128i;
+    let abef_save: __m128i;
+    let cdgh_save: __m128i;
 
-        #[allow(non_snake_case)]
-        let MASK: __m128i = _mm_set_epi64x(
-            0x0c0d_0e0f_0809_0a0bu64 as i64,
-            0x0405_0607_0001_0203u64 as i64,
-        );
-        
-        // Load initial values
-        tmp = _mm_loadu_si128(state.as_ptr().add(0) as *const __m128i);
-        state1 = _mm_loadu_si128(state.as_ptr().add(4) as *const __m128i);
+    #[allow(non_snake_case)]
+    let MASK: __m128i = _mm_set_epi64x(
+        0x0c0d_0e0f_0809_0a0bu64 as i64,
+        0x0405_0607_0001_0203u64 as i64,
+    );
+    
+    // Load initial values
+    tmp = _mm_loadu_si128(state.as_ptr().add(0) as *const __m128i);
+    state1 = _mm_loadu_si128(state.as_ptr().add(4) as *const __m128i);
 
-        tmp    = _mm_shuffle_epi32(tmp, 0xB1);       // CDAB
-        state1 = _mm_shuffle_epi32(state1, 0x1B);    // EFGH
-        state0 = _mm_alignr_epi8(tmp, state1, 8);    // ABEF
-        state1 = _mm_blend_epi16(state1, tmp, 0xF0); // CDGH
+    tmp    = _mm_shuffle_epi32(tmp, 0xB1);       // CDAB
+    state1 = _mm_shuffle_epi32(state1, 0x1B);    // EFGH
+    state0 = _mm_alignr_epi8(tmp, state1, 8);    // ABEF
+    state1 = _mm_blend_epi16(state1, tmp, 0xF0); // CDGH
 
-        // Save current state
-        abef_save = state0;
-        cdgh_save = state1;
+    // Save current state
+    abef_save = state0;
+    cdgh_save = state1;
 
-        // Rounds 0-3
-        msg = _mm_loadu_si128(block.as_ptr() as *const __m128i);
-        msg0 = _mm_shuffle_epi8(msg, MASK);
-        msg = _mm_add_epi32(msg0, _mm_set_epi64x(0xE9B5DBA5B5C0FBCFu64 as i64, 0x71374491428A2F98u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    // Rounds 0-3
+    msg = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+    msg0 = _mm_shuffle_epi8(msg, MASK);
+    msg = _mm_add_epi32(msg0, _mm_set_epi64x(0xE9B5DBA5B5C0FBCFu64 as i64, 0x71374491428A2F98u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
 
-        // Rounds 4-7
-        msg1 = _mm_loadu_si128(block.as_ptr().add(16) as *const __m128i);
-        msg1 = _mm_shuffle_epi8(msg1, MASK);
-        msg = _mm_add_epi32(msg1, _mm_set_epi64x(0xAB1C5ED5923F82A4u64 as i64, 0x59F111F13956C25Bu64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+    // Rounds 4-7
+    msg1 = _mm_loadu_si128(block.as_ptr().add(16) as *const __m128i);
+    msg1 = _mm_shuffle_epi8(msg1, MASK);
+    msg = _mm_add_epi32(msg1, _mm_set_epi64x(0xAB1C5ED5923F82A4u64 as i64, 0x59F111F13956C25Bu64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
 
-        // Rounds 8-11
-        msg2 = _mm_loadu_si128(block.as_ptr().add(32) as *const __m128i);
-        msg2 = _mm_shuffle_epi8(msg2, MASK);
-        msg = _mm_add_epi32( msg2, _mm_set_epi64x(0x550C7DC3243185BEu64 as i64, 0x12835B01D807AA98u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+    // Rounds 8-11
+    msg2 = _mm_loadu_si128(block.as_ptr().add(32) as *const __m128i);
+    msg2 = _mm_shuffle_epi8(msg2, MASK);
+    msg = _mm_add_epi32( msg2, _mm_set_epi64x(0x550C7DC3243185BEu64 as i64, 0x12835B01D807AA98u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
 
-        // Rounds 12-15
-        msg3 = _mm_loadu_si128(block.as_ptr().add(48) as *const __m128i);
-        msg3 = _mm_shuffle_epi8(msg3, MASK);
-        msg = _mm_add_epi32(msg3, _mm_set_epi64x(0xC19BF1749BDC06A7u64 as i64, 0x80DEB1FE72BE5D74u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg3, msg2, 4);
-        msg0 = _mm_add_epi32(msg0, tmp);
-        msg0 = _mm_sha256msg2_epu32(msg0, msg3);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+    // Rounds 12-15
+    msg3 = _mm_loadu_si128(block.as_ptr().add(48) as *const __m128i);
+    msg3 = _mm_shuffle_epi8(msg3, MASK);
+    msg = _mm_add_epi32(msg3, _mm_set_epi64x(0xC19BF1749BDC06A7u64 as i64, 0x80DEB1FE72BE5D74u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg3, msg2, 4);
+    msg0 = _mm_add_epi32(msg0, tmp);
+    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
 
-        // Rounds 16-19
-        msg = _mm_add_epi32(msg0, _mm_set_epi64x(0x240CA1CC0FC19DC6u64 as i64, 0xEFBE4786E49B69C1u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg0, msg3, 4);
-        msg1 = _mm_add_epi32(msg1, tmp);
-        msg1 = _mm_sha256msg2_epu32(msg1, msg0);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+    // Rounds 16-19
+    msg = _mm_add_epi32(msg0, _mm_set_epi64x(0x240CA1CC0FC19DC6u64 as i64, 0xEFBE4786E49B69C1u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg0, msg3, 4);
+    msg1 = _mm_add_epi32(msg1, tmp);
+    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
 
-        // Rounds 20-23
-        msg = _mm_add_epi32(msg1, _mm_set_epi64x(0x76F988DA5CB0A9DCu64 as i64, 0x4A7484AA2DE92C6Fu64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg1, msg0, 4);
-        msg2 = _mm_add_epi32(msg2, tmp);
-        msg2 = _mm_sha256msg2_epu32(msg2, msg1);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+    // Rounds 20-23
+    msg = _mm_add_epi32(msg1, _mm_set_epi64x(0x76F988DA5CB0A9DCu64 as i64, 0x4A7484AA2DE92C6Fu64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg1, msg0, 4);
+    msg2 = _mm_add_epi32(msg2, tmp);
+    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
 
-        // Rounds 24-27
-        msg = _mm_add_epi32(msg2, _mm_set_epi64x(0xBF597FC7B00327C8u64 as i64, 0xA831C66D983E5152u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg2, msg1, 4);
-        msg3 = _mm_add_epi32(msg3, tmp);
-        msg3 = _mm_sha256msg2_epu32(msg3, msg2);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+    // Rounds 24-27
+    msg = _mm_add_epi32(msg2, _mm_set_epi64x(0xBF597FC7B00327C8u64 as i64, 0xA831C66D983E5152u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg2, msg1, 4);
+    msg3 = _mm_add_epi32(msg3, tmp);
+    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
 
-        // Rounds 28-31
-        msg = _mm_add_epi32(msg3, _mm_set_epi64x(0x1429296706CA6351u64 as i64, 0xD5A79147C6E00BF3u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg3, msg2, 4);
-        msg0 = _mm_add_epi32(msg0, tmp);
-        msg0 = _mm_sha256msg2_epu32(msg0, msg3);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+    // Rounds 28-31
+    msg = _mm_add_epi32(msg3, _mm_set_epi64x(0x1429296706CA6351u64 as i64, 0xD5A79147C6E00BF3u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg3, msg2, 4);
+    msg0 = _mm_add_epi32(msg0, tmp);
+    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
 
-        // Rounds 32-35
-        msg = _mm_add_epi32(msg0, _mm_set_epi64x(0x53380D134D2C6DFCu64 as i64, 0x2E1B213827B70A85u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg0, msg3, 4);
-        msg1 = _mm_add_epi32(msg1, tmp);
-        msg1 = _mm_sha256msg2_epu32(msg1, msg0);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+    // Rounds 32-35
+    msg = _mm_add_epi32(msg0, _mm_set_epi64x(0x53380D134D2C6DFCu64 as i64, 0x2E1B213827B70A85u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg0, msg3, 4);
+    msg1 = _mm_add_epi32(msg1, tmp);
+    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
 
-        // Rounds 36-39
-        msg = _mm_add_epi32(msg1, _mm_set_epi64x(0x92722C8581C2C92Eu64 as i64, 0x766A0ABB650A7354u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg1, msg0, 4);
-        msg2 = _mm_add_epi32(msg2, tmp);
-        msg2 = _mm_sha256msg2_epu32(msg2, msg1);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+    // Rounds 36-39
+    msg = _mm_add_epi32(msg1, _mm_set_epi64x(0x92722C8581C2C92Eu64 as i64, 0x766A0ABB650A7354u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg1, msg0, 4);
+    msg2 = _mm_add_epi32(msg2, tmp);
+    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
 
-        // Rounds 40-43
-        msg = _mm_add_epi32(msg2, _mm_set_epi64x(0xC76C51A3C24B8B70u64 as i64, 0xA81A664BA2BFE8A1u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg2, msg1, 4);
-        msg3 = _mm_add_epi32(msg3, tmp);
-        msg3 = _mm_sha256msg2_epu32(msg3, msg2);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+    // Rounds 40-43
+    msg = _mm_add_epi32(msg2, _mm_set_epi64x(0xC76C51A3C24B8B70u64 as i64, 0xA81A664BA2BFE8A1u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg2, msg1, 4);
+    msg3 = _mm_add_epi32(msg3, tmp);
+    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
 
-        // Rounds 44-47
-        msg = _mm_add_epi32(msg3, _mm_set_epi64x(0x106AA070F40E3585u64 as i64, 0xD6990624D192E819u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg3, msg2, 4);
-        msg0 = _mm_add_epi32(msg0, tmp);
-        msg0 = _mm_sha256msg2_epu32(msg0, msg3);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+    // Rounds 44-47
+    msg = _mm_add_epi32(msg3, _mm_set_epi64x(0x106AA070F40E3585u64 as i64, 0xD6990624D192E819u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg3, msg2, 4);
+    msg0 = _mm_add_epi32(msg0, tmp);
+    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
 
-        // Rounds 48-51
-        msg = _mm_add_epi32(msg0, _mm_set_epi64x(0x34B0BCB52748774Cu64 as i64, 0x1E376C0819A4C116u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg0, msg3, 4);
-        msg1 = _mm_add_epi32(msg1, tmp);
-        msg1 = _mm_sha256msg2_epu32(msg1, msg0);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-        msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+    // Rounds 48-51
+    msg = _mm_add_epi32(msg0, _mm_set_epi64x(0x34B0BCB52748774Cu64 as i64, 0x1E376C0819A4C116u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg0, msg3, 4);
+    msg1 = _mm_add_epi32(msg1, tmp);
+    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
 
-        // Rounds 52-55
-        msg = _mm_add_epi32(msg1, _mm_set_epi64x(0x682E6FF35B9CCA4Fu64 as i64, 0x4ED8AA4A391C0CB3u64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg1, msg0, 4);
-        msg2 = _mm_add_epi32(msg2, tmp);
-        msg2 = _mm_sha256msg2_epu32(msg2, msg1);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    // Rounds 52-55
+    msg = _mm_add_epi32(msg1, _mm_set_epi64x(0x682E6FF35B9CCA4Fu64 as i64, 0x4ED8AA4A391C0CB3u64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg1, msg0, 4);
+    msg2 = _mm_add_epi32(msg2, tmp);
+    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
 
-        // Rounds 56-59
-        msg = _mm_add_epi32(msg2, _mm_set_epi64x(0x8CC7020884C87814u64 as i64, 0x78A5636F748F82EEu64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        tmp = _mm_alignr_epi8(msg2, msg1, 4);
-        msg3 = _mm_add_epi32(msg3, tmp);
-        msg3 = _mm_sha256msg2_epu32(msg3, msg2);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    // Rounds 56-59
+    msg = _mm_add_epi32(msg2, _mm_set_epi64x(0x8CC7020884C87814u64 as i64, 0x78A5636F748F82EEu64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg2, msg1, 4);
+    msg3 = _mm_add_epi32(msg3, tmp);
+    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
 
-        // Rounds 60-63
-        msg = _mm_add_epi32(msg3, _mm_set_epi64x(0xC67178F2BEF9A3F7u64 as i64, 0xA4506CEB90BEFFFAu64 as i64));
-        state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-        msg = _mm_shuffle_epi32(msg, 0x0E);
-        state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    // Rounds 60-63
+    msg = _mm_add_epi32(msg3, _mm_set_epi64x(0xC67178F2BEF9A3F7u64 as i64, 0xA4506CEB90BEFFFAu64 as i64));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
 
-        // Combine state
-        state0 = _mm_add_epi32(state0, abef_save);
-        state1 = _mm_add_epi32(state1, cdgh_save);
+    // Combine state
+    state0 = _mm_add_epi32(state0, abef_save);
+    state1 = _mm_add_epi32(state1, cdgh_save);
 
-        tmp    = _mm_shuffle_epi32(state0, 0x1B);    // FEBA
-        state1 = _mm_shuffle_epi32(state1, 0xB1);    // DCHG
-        state0 = _mm_blend_epi16(tmp, state1, 0xF0); // DCBA
-        state1 = _mm_alignr_epi8(state1, tmp, 8);    // ABEF
+    tmp    = _mm_shuffle_epi32(state0, 0x1B);    // FEBA
+    state1 = _mm_shuffle_epi32(state1, 0xB1);    // DCHG
+    state0 = _mm_blend_epi16(tmp, state1, 0xF0); // DCBA
+    state1 = _mm_alignr_epi8(state1, tmp, 8);    // ABEF
 
-        // Save state
-        _mm_storeu_si128(state.as_mut_ptr().add(0) as *mut __m128i, state0);
-        _mm_storeu_si128(state.as_mut_ptr().add(4) as *mut __m128i, state1);
-    }
+    // Save state
+    _mm_storeu_si128(state.as_mut_ptr().add(0) as *mut __m128i, state0);
+    _mm_storeu_si128(state.as_mut_ptr().add(4) as *mut __m128i, state1);
 }

--- a/src/hash/sha2/sha512/mod.rs
+++ b/src/hash/sha2/sha512/mod.rs
@@ -54,7 +54,7 @@ const SHA384_INITIAL_STATE: [u64; 8] = [
 #[cfg(target_arch = "aarch64")]
 #[inline]
 fn transform(state: &mut [u64; 8], block: &[u8]) {
-    // NOTE: 等待 Rust 的 `std_detect` 库支持 AArch64 v8.4-A。
+    // Waiting `std_detect` to support AArch64 v8.4-A
     // https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L13
     
     generic::transform(state, block)

--- a/src/mac/ghash/aarch64.rs
+++ b/src/mac/ghash/aarch64.rs
@@ -8,7 +8,7 @@ use core::mem::transmute;
 // Convert _mm_clmulepi64_si128 to vmull_{high}_p64
 // https://stackoverflow.com/questions/38553881/convert-mm-clmulepi64-si128-to-vmull-high-p64
 
-#[inline]
+#[target_feature(enable = "pmull")]
 unsafe fn pmull(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     // Low
     let a = vgetq_lane_u64(vreinterpretq_u64_u8(a), 0);
@@ -16,7 +16,7 @@ unsafe fn pmull(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     transmute(vmull_p64(a, b))
 }
 
-#[inline]
+#[target_feature(enable = "pmull")]
 unsafe fn pmull2(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     // High
     let a = vgetq_lane_u64(vreinterpretq_u64_u8(a), 1);
@@ -40,7 +40,7 @@ unsafe fn vrbitq_u8(a: uint8x16_t) -> uint8x16_t {
 
 
 // Perform the multiplication and reduction in GF(2^128)
-#[inline]
+#[target_feature(enable = "pmull")]
 unsafe fn gf_mul(key: uint8x16_t, m: &[u8], tag: &mut uint8x16_t) {
     let m = vrbitq_u8(*(m.as_ptr() as *const uint8x16_t));
 

--- a/src/mac/ghash/dynamic.rs
+++ b/src/mac/ghash/dynamic.rs
@@ -1,0 +1,42 @@
+use super::generic;
+use super::platform;
+
+#[derive(Clone)]
+pub enum GHash {
+    Generic(generic::GHash),
+    Platform(platform::GHash),
+}
+
+impl GHash {
+    pub const KEY_LEN: usize = generic::GHash::KEY_LEN;
+    pub const BLOCK_LEN: usize = generic::GHash::BLOCK_LEN;
+    pub const TAG_LEN: usize = generic::GHash::TAG_LEN;
+
+    pub fn new(h: &[u8; Self::BLOCK_LEN]) -> Self {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if std::is_x86_feature_detected!("sse2") && std::is_x86_feature_detected!("pclmulqdq") {
+            return GHash::Platform(platform::GHash::new(h));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        if std::is_aarch64_feature_detected!("pmull") {
+            return GHash::Platform(platform::GHash::new(k));
+        }
+
+        GHash::Generic(generic::GHash::new(h))
+    }
+
+    pub fn update(&mut self, m: &[u8]) {
+        match *self {
+            GHash::Generic(ref mut g) => g.update(m),
+            GHash::Platform(ref mut g) => g.update(m),
+        }
+    }
+
+    pub fn finalize(self) -> [u8; Self::TAG_LEN] {
+        match self {
+            GHash::Generic(g) => g.finalize(),
+            GHash::Platform(g) => g.finalize(),
+        }
+    }
+}

--- a/src/mac/ghash/mod.rs
+++ b/src/mac/ghash/mod.rs
@@ -1,29 +1,30 @@
 // https://github.com/randombit/botan/blob/master/src/lib/utils/ghash/ghash_vperm/ghash_vperm.cpp
 
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    all(target_feature = "sse2", target_feature = "pclmulqdq"),
-))]
-#[path = "./x86.rs"]
-mod platform;
+use cfg_if::cfg_if;
 
+cfg_if! {
+    if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
+                 all(target_feature = "sse2", target_feature = "pclmulqdq")))] {
+        mod x86;
+        pub use self::x86::GHash;
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "crypto"))] {
+        mod aarch64;
+        pub use self::aarch64::GHash;
+    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[path = "./x86.rs"]
+        mod platform;
 
-// NOTE:
-//      Crypto: AES + PMULL + SHA1 + SHA2
-//      https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L26
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto"))]
-#[path = "./aarch64.rs"]
-mod platform;
+        #[cfg(target_arch = "aarch64")]
+        #[path = "./aarch64.rs"]
+        mod platform;
 
+        mod generic;
+        mod dynamic;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        all(target_feature = "sse2", target_feature = "pclmulqdq")
-    ),
-    all(target_arch = "aarch64", target_feature = "crypto")
-)))]
-#[path = "./generic.rs"]
-mod platform;
-
-pub use self::platform::GHash;
+        pub use self::dynamic::GHash;
+    } else {
+        mod generic;
+        pub use self::generic::GHash;
+    }
+}

--- a/src/mac/ghash/mod.rs
+++ b/src/mac/ghash/mod.rs
@@ -3,26 +3,34 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
-                 all(target_feature = "sse2", target_feature = "pclmulqdq")))] {
-        mod x86;
-        pub use self::x86::GHash;
-    } else if #[cfg(all(target_arch = "aarch64", target_feature = "pmull"))] {
-        mod aarch64;
-        pub use self::aarch64::GHash;
-    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
         #[path = "./x86.rs"]
         mod platform;
 
-        #[cfg(target_arch = "aarch64")]
+        cfg_if! {
+            if #[cfg(all(target_feature = "sse2", target_feature = "pclmulqdq"))] {
+                pub use self::platform::GHash;
+            } else {
+                mod generic;
+                mod dynamic;
+
+                pub use self::dynamic::GHash;
+            }
+        }
+    } else if #[cfg(target_arch = "aarch64")] {
         #[path = "./aarch64.rs"]
         mod platform;
 
-        mod generic;
-        mod dynamic;
+        cfg_if! {
+            if #[cfg(target_feature = "pmull")] {
+                pub use self::platform::GHash;
+            } else {
+                mod generic;
+                mod dynamic;
 
-        pub use self::dynamic::GHash;
+                pub use self::dynamic::GHash;
+            }
+        }
     } else {
         mod generic;
         pub use self::generic::GHash;

--- a/src/mac/ghash/mod.rs
+++ b/src/mac/ghash/mod.rs
@@ -7,7 +7,7 @@ cfg_if! {
                  all(target_feature = "sse2", target_feature = "pclmulqdq")))] {
         mod x86;
         pub use self::x86::GHash;
-    } else if #[cfg(all(target_arch = "aarch64", target_feature = "crypto"))] {
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "pmull"))] {
         mod aarch64;
         pub use self::aarch64::GHash;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {

--- a/src/mac/ghash/x86.rs
+++ b/src/mac/ghash/x86.rs
@@ -17,80 +17,87 @@ impl GHash {
     pub const BLOCK_LEN: usize = 16;
     pub const TAG_LEN: usize   = 16;
 
-
+    #[inline(always)]
     pub fn new(key: &[u8; Self::KEY_LEN]) -> Self {
+        unsafe { Self::new_simd(key) }
+    }
+
+    #[target_feature(enable = "sse2,pclmulqdq")]
+    unsafe fn new_simd(key: &[u8; Self::KEY_LEN]) -> Self {
         let key = key.clone();
         
-        unsafe {
-            let tag = _mm_setzero_si128();
-            let vm = _mm_setr_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-            let key = _mm_shuffle_epi8(_mm_loadu_si128(key.as_ptr() as *const __m128i), vm);
+        let tag = _mm_setzero_si128();
+        let vm = _mm_setr_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+        let key = _mm_shuffle_epi8(_mm_loadu_si128(key.as_ptr() as *const __m128i), vm);
 
-            Self { key, buf: tag, }
-        }
+        Self { key, buf: tag, }
     }
     
     // Performing Ghash Using Algorithms 1 and 5 (C)
     #[inline]
-    fn gf_mul(&mut self, x: &[u8]) {
-        unsafe {
-            let a = self.key;
+    unsafe fn gf_mul(&mut self, x: &[u8]) {
+        let a = self.key;
 
-            let vm = _mm_setr_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-            let mut b = _mm_loadu_si128(x.as_ptr() as *const __m128i);
-            b = _mm_shuffle_epi8(b, vm);
-            b = _mm_xor_si128(b, self.buf);
+        let vm = _mm_setr_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+        let mut b = _mm_loadu_si128(x.as_ptr() as *const __m128i);
+        b = _mm_shuffle_epi8(b, vm);
+        b = _mm_xor_si128(b, self.buf);
 
-            let mut tmp2: __m128i = core::mem::zeroed();
-            let mut tmp3: __m128i = core::mem::zeroed();
-            let mut tmp4: __m128i = core::mem::zeroed();
-            let mut tmp5: __m128i = core::mem::zeroed();
-            let mut tmp6: __m128i = core::mem::zeroed();
-            let mut tmp7: __m128i = core::mem::zeroed();
-            let mut tmp8: __m128i = core::mem::zeroed();
-            let mut tmp9: __m128i = core::mem::zeroed();
+        let mut tmp2: __m128i = core::mem::zeroed();
+        let mut tmp3: __m128i = core::mem::zeroed();
+        let mut tmp4: __m128i = core::mem::zeroed();
+        let mut tmp5: __m128i = core::mem::zeroed();
+        let mut tmp6: __m128i = core::mem::zeroed();
+        let mut tmp7: __m128i = core::mem::zeroed();
+        let mut tmp8: __m128i = core::mem::zeroed();
+        let mut tmp9: __m128i = core::mem::zeroed();
 
-            tmp3 = _mm_clmulepi64_si128(a, b, 0x00);
-            tmp4 = _mm_clmulepi64_si128(a, b, 0x10);
-            tmp5 = _mm_clmulepi64_si128(a, b, 0x01);
-            tmp6 = _mm_clmulepi64_si128(a, b, 0x11);
-            tmp4 = _mm_xor_si128(tmp4, tmp5);
-            tmp5 = _mm_slli_si128(tmp4, 8);
-            tmp4 = _mm_srli_si128(tmp4, 8);
-            tmp3 = _mm_xor_si128(tmp3, tmp5);
-            tmp6 = _mm_xor_si128(tmp6, tmp4);
-            tmp7 = _mm_srli_epi32(tmp3, 31);
-            tmp8 = _mm_srli_epi32(tmp6, 31);
-            tmp3 = _mm_slli_epi32(tmp3, 1);
-            tmp6 = _mm_slli_epi32(tmp6, 1);
-            tmp9 = _mm_srli_si128(tmp7, 12);
-            tmp8 = _mm_slli_si128(tmp8, 4);
-            tmp7 = _mm_slli_si128(tmp7, 4);
-            tmp3 = _mm_or_si128(tmp3, tmp7);
-            tmp6 = _mm_or_si128(tmp6, tmp8);
-            tmp6 = _mm_or_si128(tmp6, tmp9);
-            tmp7 = _mm_slli_epi32(tmp3, 31);
-            tmp8 = _mm_slli_epi32(tmp3, 30);
-            tmp9 = _mm_slli_epi32(tmp3, 25);
-            tmp7 = _mm_xor_si128(tmp7, tmp8);
-            tmp7 = _mm_xor_si128(tmp7, tmp9);
-            tmp8 = _mm_srli_si128(tmp7, 4);
-            tmp7 = _mm_slli_si128(tmp7, 12);
-            tmp3 = _mm_xor_si128(tmp3, tmp7);
-            tmp2 = _mm_srli_epi32(tmp3, 1);
-            tmp4 = _mm_srli_epi32(tmp3, 2);
-            tmp5 = _mm_srli_epi32(tmp3, 7);
-            tmp2 = _mm_xor_si128(tmp2, tmp4);
-            tmp2 = _mm_xor_si128(tmp2, tmp5);
-            tmp2 = _mm_xor_si128(tmp2, tmp8);
-            tmp3 = _mm_xor_si128(tmp3, tmp2);
-            tmp6 = _mm_xor_si128(tmp6, tmp3);
-            
-            _mm_storeu_si128(&mut self.buf as _, tmp6);
-        }
+        tmp3 = _mm_clmulepi64_si128(a, b, 0x00);
+        tmp4 = _mm_clmulepi64_si128(a, b, 0x10);
+        tmp5 = _mm_clmulepi64_si128(a, b, 0x01);
+        tmp6 = _mm_clmulepi64_si128(a, b, 0x11);
+        tmp4 = _mm_xor_si128(tmp4, tmp5);
+        tmp5 = _mm_slli_si128(tmp4, 8);
+        tmp4 = _mm_srli_si128(tmp4, 8);
+        tmp3 = _mm_xor_si128(tmp3, tmp5);
+        tmp6 = _mm_xor_si128(tmp6, tmp4);
+        tmp7 = _mm_srli_epi32(tmp3, 31);
+        tmp8 = _mm_srli_epi32(tmp6, 31);
+        tmp3 = _mm_slli_epi32(tmp3, 1);
+        tmp6 = _mm_slli_epi32(tmp6, 1);
+        tmp9 = _mm_srli_si128(tmp7, 12);
+        tmp8 = _mm_slli_si128(tmp8, 4);
+        tmp7 = _mm_slli_si128(tmp7, 4);
+        tmp3 = _mm_or_si128(tmp3, tmp7);
+        tmp6 = _mm_or_si128(tmp6, tmp8);
+        tmp6 = _mm_or_si128(tmp6, tmp9);
+        tmp7 = _mm_slli_epi32(tmp3, 31);
+        tmp8 = _mm_slli_epi32(tmp3, 30);
+        tmp9 = _mm_slli_epi32(tmp3, 25);
+        tmp7 = _mm_xor_si128(tmp7, tmp8);
+        tmp7 = _mm_xor_si128(tmp7, tmp9);
+        tmp8 = _mm_srli_si128(tmp7, 4);
+        tmp7 = _mm_slli_si128(tmp7, 12);
+        tmp3 = _mm_xor_si128(tmp3, tmp7);
+        tmp2 = _mm_srli_epi32(tmp3, 1);
+        tmp4 = _mm_srli_epi32(tmp3, 2);
+        tmp5 = _mm_srli_epi32(tmp3, 7);
+        tmp2 = _mm_xor_si128(tmp2, tmp4);
+        tmp2 = _mm_xor_si128(tmp2, tmp5);
+        tmp2 = _mm_xor_si128(tmp2, tmp8);
+        tmp3 = _mm_xor_si128(tmp3, tmp2);
+        tmp6 = _mm_xor_si128(tmp6, tmp3);
+        
+        _mm_storeu_si128(&mut self.buf as _, tmp6);
     }
 
+    #[inline(always)]
     pub fn update(&mut self, m: &[u8]) {
+        unsafe { self.update_simd(m) }
+    }
+
+    #[target_feature(enable = "sse2,pclmulqdq")]
+    unsafe fn update_simd(&mut self, m: &[u8]) {
         let mlen = m.len();
 
         if mlen == 0 {
@@ -113,14 +120,18 @@ impl GHash {
         }
     }
 
+    #[inline(always)]
     pub fn finalize(self) -> [u8; Self::TAG_LEN] {
-        unsafe {
-            let mut out = [0u8; Self::TAG_LEN];
+        unsafe { self.finalize_simd() }
+    }
 
-            let vm = _mm_setr_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-            _mm_storeu_si128(out.as_mut_ptr() as *mut __m128i, _mm_shuffle_epi8(self.buf, vm));
-            out
-        }
+    #[target_feature(enable = "sse2,pclmulqdq")]
+    unsafe fn finalize_simd(self) -> [u8; Self::TAG_LEN] {
+        let mut out = [0u8; Self::TAG_LEN];
+
+        let vm = _mm_setr_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+        _mm_storeu_si128(out.as_mut_ptr() as *mut __m128i, _mm_shuffle_epi8(self.buf, vm));
+        out
     }
 }
 

--- a/src/mac/polyval/aarch64.rs
+++ b/src/mac/polyval/aarch64.rs
@@ -3,7 +3,7 @@ use core::arch::aarch64::*;
 use core::mem::transmute;
 
 
-#[inline]
+#[target_feature(enable = "pmull")]
 unsafe fn _mm_clmulepi64_si128(a: uint8x16_t, b: uint8x16_t, imm8: u8) -> uint8x16_t {
     match imm8 {
         0x00 => {
@@ -41,67 +41,73 @@ impl Polyval {
     pub const BLOCK_LEN: usize = 16;
     pub const TAG_LEN: usize   = 16;
 
-
+    #[inline(always)]
     pub fn new(k: &[u8]) -> Self {
-        assert_eq!(k.len(), Self::KEY_LEN);
-        
-        unsafe {
-            let h = vdupq_n_u8(0);
-            let key: uint8x16_t = *(k.as_ptr() as *const uint8x16_t).clone();
-
-            Self { key, h  }
-        }
+        unsafe { Self::new_simd(k) }
     }
 
-    #[inline]
-    fn gf_mul(&mut self, block: &[u8]) {
-        unsafe {
-            let mask: uint8x16_t = transmute([1u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 194]);
+    #[target_feature(enable = "pmull")]
+    unsafe fn new_simd(k: &[u8]) -> Self {
+        assert_eq!(k.len(), Self::KEY_LEN);
+        
+        let h = vdupq_n_u8(0);
+        let key: uint8x16_t = *(k.as_ptr() as *const uint8x16_t).clone();
 
-            let a = veorq_u8(self.h, *(block.as_ptr() as *const uint8x16_t));
-            let b = self.key;
+        Self { key, h  }
+    }
 
-            let mut tmp1 = _mm_clmulepi64_si128(a, b, 0x00);
-            let mut tmp4 = _mm_clmulepi64_si128(a, b, 0x11);
-            let mut tmp2 = _mm_clmulepi64_si128(a, b, 0x10);
-            let mut tmp3 = _mm_clmulepi64_si128(a, b, 0x01);
+    #[target_feature(enable = "pmull")]
+    unsafe fn gf_mul(&mut self, block: &[u8]) {
+        let mask: uint8x16_t = transmute([1u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 194]);
+
+        let a = veorq_u8(self.h, *(block.as_ptr() as *const uint8x16_t));
+        let b = self.key;
+
+        let mut tmp1 = _mm_clmulepi64_si128(a, b, 0x00);
+        let mut tmp4 = _mm_clmulepi64_si128(a, b, 0x11);
+        let mut tmp2 = _mm_clmulepi64_si128(a, b, 0x10);
+        let mut tmp3 = _mm_clmulepi64_si128(a, b, 0x01);
 
 
-            tmp2 = veorq_u8(tmp2, tmp3);
-            tmp3 = transmute::<u128, uint8x16_t>(transmute::<uint8x16_t, u128>(tmp2) << 64);
-            // vgetq_lane_u64(vreinterpretq_u64_u8(a), 1)
+        tmp2 = veorq_u8(tmp2, tmp3);
+        tmp3 = transmute::<u128, uint8x16_t>(transmute::<uint8x16_t, u128>(tmp2) << 64);
+        // vgetq_lane_u64(vreinterpretq_u64_u8(a), 1)
 
-            tmp2 = transmute::<u128, uint8x16_t>(transmute::<uint8x16_t, u128>(tmp2) >> 64);
+        tmp2 = transmute::<u128, uint8x16_t>(transmute::<uint8x16_t, u128>(tmp2) >> 64);
 
-            tmp1 = veorq_u8(tmp3, tmp1);
-            tmp4 = veorq_u8(tmp4, tmp2);
+        tmp1 = veorq_u8(tmp3, tmp1);
+        tmp4 = veorq_u8(tmp4, tmp2);
 
-            tmp2 = _mm_clmulepi64_si128(tmp1, mask, 0x10);
+        tmp2 = _mm_clmulepi64_si128(tmp1, mask, 0x10);
 
-            // 0b 01 00 11 10
-            //    1   0  3  2
-            // tmp3 = _mm_shuffle_epi32(tmp1, 78);
-            {
-                let [t0, t1, t2, t3] = transmute::<uint8x16_t, [u32; 4]>(tmp1);
-                tmp3 = transmute([t2, t3, t0, t1]);
-            }
-            
-            tmp1 = veorq_u8(tmp3, tmp2);
-            
-            tmp2 = _mm_clmulepi64_si128(tmp1, mask, 0x10);
-
-            {
-                let [t0, t1, t2, t3]: [u32; 4] = transmute(tmp1);
-                tmp3 = transmute([t2, t3, t0, t1]);
-            }
-
-            tmp1 = veorq_u8(tmp3, tmp2);
-            
-            self.h = veorq_u8(tmp4, tmp1);
+        // 0b 01 00 11 10
+        //    1   0  3  2
+        // tmp3 = _mm_shuffle_epi32(tmp1, 78);
+        {
+            let [t0, t1, t2, t3] = transmute::<uint8x16_t, [u32; 4]>(tmp1);
+            tmp3 = transmute([t2, t3, t0, t1]);
         }
+        
+        tmp1 = veorq_u8(tmp3, tmp2);
+        
+        tmp2 = _mm_clmulepi64_si128(tmp1, mask, 0x10);
+
+        {
+            let [t0, t1, t2, t3]: [u32; 4] = transmute(tmp1);
+            tmp3 = transmute([t2, t3, t0, t1]);
+        }
+
+        tmp1 = veorq_u8(tmp3, tmp2);
+        
+        self.h = veorq_u8(tmp4, tmp1);
     }
 
     pub fn update(&mut self, m: &[u8]) {
+        unsafe { self.update_simd(m) }
+    }
+
+    #[target_feature(enable = "pmull")]
+    unsafe fn update_simd(&mut self, m: &[u8]) {
         let mlen = m.len();
 
         for chunk in m.chunks_exact(Self::BLOCK_LEN) {

--- a/src/mac/polyval/dynamic.rs
+++ b/src/mac/polyval/dynamic.rs
@@ -1,0 +1,41 @@
+use super::generic;
+use super::platform;
+
+pub enum Polyval {
+    Generic(generic::Polyval),
+    Platform(platform::Polyval),
+}
+
+impl Polyval {
+    pub const KEY_LEN: usize = generic::Polyval::KEY_LEN;
+    pub const BLOCK_LEN: usize = generic::Polyval::BLOCK_LEN;
+    pub const TAG_LEN: usize = generic::Polyval::TAG_LEN;
+
+    pub fn new(k: &[u8]) -> Self {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if std::is_x86_feature_detected!("sse2") && std::is_x86_feature_detected!("pclmulqdq") {
+            return Polyval::Platform(platform::Polyval::new(k));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        if std::is_aarch64_feature_detected!("pmull") {
+            return Polyval::Platform(platform::Polyval::new(k));
+        }
+
+        Polyval::Generic(generic::Polyval::new(k))
+    }
+
+    pub fn update(&mut self, m: &[u8]) {
+        match *self {
+            Polyval::Generic(ref mut g) => g.update(m),
+            Polyval::Platform(ref mut g) => g.update(m),
+        }
+    }
+
+    pub fn finalize(self) -> [u8; Self::TAG_LEN] {
+        match self {
+            Polyval::Generic(g) => g.finalize(),
+            Polyval::Platform(g) => g.finalize(),
+        }
+    }
+}

--- a/src/mac/polyval/mod.rs
+++ b/src/mac/polyval/mod.rs
@@ -5,7 +5,7 @@ cfg_if! {
                  all(target_feature = "sse2", target_feature = "pclmulqdq")))] {
         mod x86;
         pub use self::x86::Polyval;
-    } else if #[cfg(all(target_arch = "aarch64", target_feature = "crypto"))] {
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "pmull"))] {
         mod aarch64;
         pub use self::aarch64::Polyval;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {

--- a/src/mac/polyval/mod.rs
+++ b/src/mac/polyval/mod.rs
@@ -1,23 +1,28 @@
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), all(target_feature = "sse2", target_feature = "pclmulqdq")))]
-#[path = "./x86.rs"]
-mod platform;
+use cfg_if::cfg_if;
 
-// NOTE:
-//      Crypto: AES + PMULL + SHA1 + SHA2
-//      https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/arch/aarch64.rs#L26
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto"))]
-#[path = "./aarch64.rs"]
-mod platform;
+cfg_if! {
+    if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
+                 all(target_feature = "sse2", target_feature = "pclmulqdq")))] {
+        mod x86;
+        pub use self::x86::Polyval;
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "crypto"))] {
+        mod aarch64;
+        pub use self::aarch64::Polyval;
+    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[path = "./x86.rs"]
+        mod platform;
 
+        #[cfg(target_arch = "aarch64")]
+        #[path = "./aarch64.rs"]
+        mod platform;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        all(target_feature = "sse2", target_feature = "pclmulqdq")
-    ),
-    all(target_arch = "aarch64", target_feature = "crypto")
-)))]
-#[path = "./generic.rs"]
-mod platform;
+        mod generic;
+        mod dynamic;
 
-pub use self::platform::Polyval;
+        pub use self::dynamic::Polyval;
+    } else {
+        mod generic;
+        pub use self::generic::Polyval;
+    }
+}

--- a/src/mac/polyval/mod.rs
+++ b/src/mac/polyval/mod.rs
@@ -1,26 +1,34 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
-                 all(target_feature = "sse2", target_feature = "pclmulqdq")))] {
-        mod x86;
-        pub use self::x86::Polyval;
-    } else if #[cfg(all(target_arch = "aarch64", target_feature = "pmull"))] {
-        mod aarch64;
-        pub use self::aarch64::Polyval;
-    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))] {
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
         #[path = "./x86.rs"]
         mod platform;
 
-        #[cfg(target_arch = "aarch64")]
+        cfg_if! {
+            if #[cfg(all(target_feature = "sse2", target_feature = "pclmulqdq"))] {
+                pub use self::platform::Polyval;
+            } else {
+                mod generic;
+                mod dynamic;
+
+                pub use self::dynamic::Polyval;
+            }
+        }
+    } else if #[cfg(target_arch = "aarch64")] {
         #[path = "./aarch64.rs"]
         mod platform;
 
-        mod generic;
-        mod dynamic;
+        cfg_if! {
+            if #[cfg(target_feature = "pmull")] {
+                pub use self::platform::Polyval;
+            } else {
+                mod generic;
+                mod dynamic;
 
-        pub use self::dynamic::Polyval;
+                pub use self::dynamic::Polyval;
+            }
+        }
     } else {
         mod generic;
         pub use self::generic::Polyval;

--- a/src/util/and.rs
+++ b/src/util/and.rs
@@ -1,43 +1,58 @@
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-#[cfg(target_arch = "aarch64")]
-use core::arch::aarch64::*;
 
+use cfg_if::cfg_if;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "sse2",
-    ),
-    target_arch = "aarch64",
-)))]
-pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+cfg_if! {
+    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+        fn and_si128_inplace_sse2(a: &mut [u8], b: &[u8]) {
+            unsafe {
+                let mut c = _mm_loadu_si128(a.as_ptr() as *const __m128i);
+                let d = _mm_loadu_si128(b.as_ptr() as *const __m128i);
+                c = _mm_and_si128(c, d);
+                _mm_storeu_si128(a.as_mut_ptr() as *mut __m128i, c);
+            }
+        }
+
+        #[cfg(target_feature = "sse2")]
+        #[inline]
+        pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+            and_si128_inplace_sse2(a, b)
+        }
+
+        #[cfg(not(target_feature = "sse2"))]
+        #[inline]
+        pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+            if std::is_x86_feature_detected!("sse2") {
+                and_si128_inplace_sse2(a, b)
+            } else {
+                and_si128_inplace_generic(a, b)
+            }
+        }
+    } else if #[cfg(target_arch = "aarch64")] {
+        pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+            unsafe {
+                let c: *mut uint8x16_t = a.as_mut_ptr() as *mut uint8x16_t;
+                let d: uint8x16_t = *(b.as_ptr() as *const uint8x16_t);
+
+                *c = vandq_u8(*c, d);
+            }
+        }
+    } else {
+        #[inline]
+        pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
+            and_si128_inplace_generic(a, b)
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn and_si128_inplace_generic(a: &mut [u8], b: &[u8]) {
     for i in 0..16 {
         a[i] &= b[i]
-    }
-}
-
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    all(target_feature = "sse2"),
-))]
-pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
-    unsafe {
-        let mut c = _mm_loadu_si128(a.as_ptr() as *const __m128i);
-        let d = _mm_loadu_si128(b.as_ptr() as *const __m128i);
-        c = _mm_and_si128(c, d);
-        _mm_storeu_si128(a.as_mut_ptr() as *mut __m128i, c);
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-pub fn and_si128_inplace(a: &mut [u8], b: &[u8]) {
-    unsafe {
-        let c: *mut uint8x16_t = a.as_mut_ptr() as *mut uint8x16_t;
-        let d: uint8x16_t = *(b.as_ptr() as *const uint8x16_t);
-        
-        *c = vandq_u8(*c, d);
     }
 }

--- a/src/util/xor.rs
+++ b/src/util/xor.rs
@@ -1,49 +1,62 @@
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-#[cfg(target_arch = "aarch64")]
-use core::arch::aarch64::*;
 
+use cfg_if::cfg_if;
 
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "sse2",
-    ),
-    target_arch = "aarch64",
-)))]
-pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+cfg_if! {
+    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+        pub fn xor_si128_inplace_sse2(a: &mut [u8], b: &[u8]) {
+            unsafe {
+                let mut c = _mm_loadu_si128(a.as_ptr() as *const __m128i);
+                let d = _mm_loadu_si128(b.as_ptr() as *const __m128i);
+                c = _mm_xor_si128(c, d);
+                _mm_storeu_si128(a.as_mut_ptr() as *mut __m128i, c);
+            }
+        }
+
+        #[cfg(target_feature = "sse2")]
+        #[inline]
+        pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+            xor_si128_inplace_sse2(a, b)
+        }
+
+        #[cfg(not(target_feature = "sse2"))]
+        #[inline]
+        pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+            if std::is_x86_feature_detected!("sse2") {
+                xor_si128_inplace_sse2(a, b)
+            } else {
+                xor_si128_inplace_generic(a, b)
+            }
+        }
+    } else if #[cfg(target_arch = "aarch64")] {
+        pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+            unsafe {
+                let c: *mut uint8x16_t = a.as_mut_ptr() as *mut uint8x16_t;
+                let d: uint8x16_t = *(b.as_ptr() as *const uint8x16_t);
+
+                *c = veorq_u8(*c, d);
+            }
+        }
+    } else {
+        #[inline]
+        pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
+            xor_si128_inplace_generic(a, b)
+        }
+    }
+
+}
+
+#[allow(dead_code)]
+fn xor_si128_inplace_generic(a: &mut [u8], b: &[u8]) {
     for i in 0..16 {
         a[i] ^= b[i]
     }
 }
-
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    all(target_feature = "sse2"),
-))]
-pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
-    unsafe {
-        let mut c = _mm_loadu_si128(a.as_ptr() as *const __m128i);
-        let d = _mm_loadu_si128(b.as_ptr() as *const __m128i);
-        c = _mm_xor_si128(c, d);
-        _mm_storeu_si128(a.as_mut_ptr() as *mut __m128i, c);
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
-    unsafe {
-        let c: *mut uint8x16_t = a.as_mut_ptr() as *mut uint8x16_t;
-        let d: uint8x16_t = *(b.as_ptr() as *const uint8x16_t);
-        
-        *c = veorq_u8(*c, d);
-    }
-}
-
-
-
 
 // #[cfg(all(
 //     any(target_arch = "x86", target_arch = "x86_64"),
@@ -58,8 +71,6 @@ pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
 //     }
 // }
 
-
-
 // #[cfg(all(
 //     any(target_arch = "x86", target_arch = "x86_64"),
 //     all(target_feature = "avx512f"),
@@ -67,10 +78,10 @@ pub fn xor_si128_inplace(a: &mut [u8], b: &[u8]) {
 // pub fn xor_si512_inplace(a: &mut [u8], b: &[u8]) {
 //     // __m512i _mm512_loadu_si512 (void const* mem_addr)
 //     // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_loadu_si512&expand=101,97,100,6171,94,97,100,3420
-//     // 
+//     //
 //     // __m512i _mm512_xor_si512 (__m512i a, __m512i b)
 //     // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_xor_si512&expand=101,97,100,6171,94,97,100,3420,6172
-//     // 
+//     //
 //     // void _mm512_storeu_si512 (void* mem_addr, __m512i a)
 //     // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_storeu_si512&expand=101,97,100,6171,94,97,100,3420,5657
 //     unsafe {


### PR DESCRIPTION
When compile without required features, such as `aes` on x86, `crypto` on Aarch64, this PR will try to enable the optimization in the runtime.

If it is compiled with required features, then there will be exactly the same as the current implementation.